### PR TITLE
Adds project reactor

### DIFF
--- a/langchain4j-reactor/pom.xml
+++ b/langchain4j-reactor/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-spring</artifactId>
+        <version>0.28.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-reactor</artifactId>
+    <name>LangChain4j Reactor</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+</project>

--- a/langchain4j-reactor/src/main/java/dev/langchain4j/reactor/chat/FluxStreamingChatLanguageModel.java
+++ b/langchain4j-reactor/src/main/java/dev/langchain4j/reactor/chat/FluxStreamingChatLanguageModel.java
@@ -1,0 +1,32 @@
+package dev.langchain4j.reactor.chat;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.model.StreamingResponseHandler;
+import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.output.Response;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+
+public interface FluxStreamingChatLanguageModel extends StreamingChatLanguageModel {
+    default Flux<AiMessage> generate(List<ChatMessage> messages) {
+        return Flux.create(sink -> generate(messages, new StreamingResponseHandler<AiMessage>() {
+            @Override
+            public void onNext(String token) {
+                sink.next(AiMessage.from(token));
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                sink.error(error);
+            }
+
+            @Override
+            public void onComplete(Response<AiMessage> response) {
+                sink.next(response.content());
+                sink.complete();
+            }
+        }));
+    }
+}

--- a/langchain4j-reactor/src/main/java/dev/langchain4j/reactor/language/FluxStreamingLanguageModel.java
+++ b/langchain4j-reactor/src/main/java/dev/langchain4j/reactor/language/FluxStreamingLanguageModel.java
@@ -1,0 +1,29 @@
+package dev.langchain4j.reactor.language;
+
+import dev.langchain4j.model.StreamingResponseHandler;
+import dev.langchain4j.model.input.Prompt;
+import dev.langchain4j.model.language.StreamingLanguageModel;
+import dev.langchain4j.model.output.Response;
+import reactor.core.publisher.Flux;
+
+public interface FluxStreamingLanguageModel extends StreamingLanguageModel {
+    default Flux<String> generate(Prompt prompt) {
+        return Flux.create(sink -> generate(prompt, new StreamingResponseHandler<String>() {
+            @Override
+            public void onNext(String token) {
+                sink.next(token);
+            }
+
+            @Override
+            public void onComplete(Response<String> response) {
+                sink.next(response.content());
+                sink.complete();
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                sink.error(error);
+            }
+        }));
+    }
+}

--- a/langchain4j-reactor/src/test/java/dev/langchain4j/reactor/chat/FluxStreamingChatLanguageModelTest.java
+++ b/langchain4j-reactor/src/test/java/dev/langchain4j/reactor/chat/FluxStreamingChatLanguageModelTest.java
@@ -1,0 +1,38 @@
+package dev.langchain4j.reactor.chat;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.StreamingResponseHandler;
+import dev.langchain4j.model.output.Response;
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+class FluxStreamingChatLanguageModelTest {
+
+    public static class StreamingUpperCaseEchoModel implements FluxStreamingChatLanguageModel {
+        @Override
+        public void generate(List<ChatMessage> messages, StreamingResponseHandler<AiMessage> handler) {
+            ChatMessage lastMessage = messages.get(messages.size() - 1);
+            Response<AiMessage> response = new Response<>(new AiMessage(lastMessage.text().toUpperCase(Locale.ROOT)));
+            handler.onComplete(response);
+        }
+    }
+
+    @Test
+    public void test_generate() {
+        FluxStreamingChatLanguageModel model = new StreamingUpperCaseEchoModel();
+        List<ChatMessage> messages = new ArrayList<>();
+        messages.add(new UserMessage("Hello"));
+        messages.add(new AiMessage("Hi"));
+        messages.add(new UserMessage("How are you?"));
+
+        StepVerifier.create(model.generate(messages))
+                .expectNext(new AiMessage("HOW ARE YOU?"))
+                .verifyComplete();
+    }
+}

--- a/langchain4j-reactor/src/test/java/dev/langchain4j/reactor/language/FluxStreamingLanguageModelTest.java
+++ b/langchain4j-reactor/src/test/java/dev/langchain4j/reactor/language/FluxStreamingLanguageModelTest.java
@@ -1,0 +1,25 @@
+package dev.langchain4j.reactor.language;
+
+import dev.langchain4j.model.StreamingResponseHandler;
+import dev.langchain4j.model.input.Prompt;
+import dev.langchain4j.model.output.Response;
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
+class FluxStreamingLanguageModelTest {
+
+    public static class EchoStreamingLanguageModel implements FluxStreamingLanguageModel {
+        @Override
+        public void generate(String prompt, StreamingResponseHandler<String> handler) {
+            handler.onComplete(new Response<>(prompt));
+        }
+    }
+
+    @Test
+    public void test_generate_flux() {
+        FluxStreamingLanguageModel model = new EchoStreamingLanguageModel();
+        StepVerifier.create(model.generate(new Prompt("text")))
+                .expectNext("text")
+                .verifyComplete();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     <modules>
         <module>langchain4j-ollama-spring-boot-starter</module>
         <module>langchain4j-open-ai-spring-boot-starter</module>
+        <module>langchain4j-reactor</module>
     </modules>
 
     <properties>
@@ -23,6 +24,8 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.boot.version>2.7.18</spring.boot.version>
+        <project.reactor.version>3.6.3</project.reactor.version>
+        <junit.version>5.10.0</junit.version>
     </properties>
 
     <dependencyManagement>
@@ -64,6 +67,26 @@
                 <version>1.19.2</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>io.projectreactor</groupId>
+                <artifactId>reactor-core</artifactId>
+                <version>${project.reactor.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.projectreactor</groupId>
+                <artifactId>reactor-test</artifactId>
+                <version>${project.reactor.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
This PR introduces a dependency on Project Reactor to facilitate the use of [Flux](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html) for streaming responses.
It was mentioned in [#689](https://github.com/langchain4j/langchain4j/issues/689)

As suggested in [this discussion](https://github.com/langchain4j/langchain4j/pull/731), a new module has been added to this repository. However, it's worth noting that this addition isn't directly associated with Spring since it solely utilizes the Project Reactor dependency and doesn't rely on Spring Webflux. Therefore, if you believe the new module would be better suited in another repository, I'm open to relocating it.