### PR TITLE
New Baseline: Spring Boot 3 and Java 17

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
   java_build:
     strategy:
       matrix:
-        java_version: [ 8, 11, 17, 21 ]
+        java_version: [ 17, 21, 22 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'temurin'
           cache: maven
           server-id: ossrh

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,6 @@
+# Use sdkman to run "sdk env" to initialize with correct JDK version
+# Enable auto-env through the sdkman_auto_env config
+# See https://sdkman.io/usage#config
+# A summary is to add the following to ~/.sdkman/etc/config
+# sdkman_auto_env=true
+java=17.0.11-tem

--- a/langchain4j-anthropic-spring-boot-starter/pom.xml
+++ b/langchain4j-anthropic-spring-boot-starter/pom.xml
@@ -53,13 +53,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.junit-pioneer</groupId>
-            <artifactId>junit-pioneer</artifactId>
-            <version>1.9.1</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
     <licenses>

--- a/langchain4j-anthropic-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/langchain4j-anthropic-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=dev.langchain4j.anthropic.spring.AutoConfig

--- a/langchain4j-anthropic-spring-boot-starter/src/test/java/dev/langchain4j/anthropic/spring/AutoConfigIT.java
+++ b/langchain4j-anthropic-spring-boot-starter/src/test/java/dev/langchain4j/anthropic/spring/AutoConfigIT.java
@@ -8,7 +8,7 @@ import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 import dev.langchain4j.model.output.Response;
 import org.junit.jupiter.api.AfterEach;
-import org.junitpioneer.jupiter.RetryingTest;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
@@ -29,7 +29,7 @@ class AutoConfigIT {
         Thread.sleep(10_000); // to avoid hitting rate limits
     }
 
-    @RetryingTest(maxAttempts = 3, suspendForMs = 10_000)
+    @Test
     void should_provide_chat_model() {
         contextRunner
                 .withPropertyValues(
@@ -46,7 +46,7 @@ class AutoConfigIT {
                 });
     }
 
-    @RetryingTest(maxAttempts = 3, suspendForMs = 10_000)
+    @Test
     void should_provide_streaming_chat_model() {
         contextRunner
                 .withPropertyValues(

--- a/langchain4j-azure-ai-search-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/langchain4j-azure-ai-search-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-dev.langchain4j.azure.aisearch.spring.AutoConfig

--- a/langchain4j-azure-open-ai-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/langchain4j-azure-open-ai-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-dev.langchain4j.azure.openai.spring.AutoConfig

--- a/langchain4j-easy-rag-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/langchain4j-easy-rag-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=dev.langchain4j.rag.easy.spring.EasyRagAutoConfig

--- a/langchain4j-ollama-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/langchain4j-ollama-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=dev.langchain4j.ollama.spring.AutoConfig

--- a/langchain4j-open-ai-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/langchain4j-open-ai-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=dev.langchain4j.openai.spring.AutoConfig

--- a/langchain4j-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/langchain4j-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=dev.langchain4j.spring.LangChain4jAutoConfig

--- a/pom.xml
+++ b/pom.xml
@@ -24,10 +24,10 @@
     </modules>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.boot.version>2.7.18</spring.boot.version>
+        <spring.boot.version>3.2.6</spring.boot.version>
     </properties>
 
     <dependencyManagement>
@@ -60,13 +60,13 @@
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.18.30</version>
+                <version>1.18.32</version>
             </dependency>
 
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers-bom</artifactId>
-                <version>1.19.2</version>
+                <version>1.19.8</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
* Minimum supported version of Java is now 17
* Minimum supported version of Spring Boot is now 3.2

Spring Boot versions older than 3.2 reached EOL and will not receive any further support nor security patches. It would be a security risk to continue using EOL-ed versions in this LangChain4j project.

More information: https://spring.io/projects/spring-boot#support