### PR TITLE
Update Elasticsearch spring implementation for 0.34

### DIFF
--- a/langchain4j-spring-boot-tests/src/test/java/dev/langchain4j/store/embedding/spring/EmbeddingStoreAutoConfigurationIT.java
+++ b/langchain4j-spring-boot-tests/src/test/java/dev/langchain4j/store/embedding/spring/EmbeddingStoreAutoConfigurationIT.java
@@ -9,6 +9,7 @@ import dev.langchain4j.store.embedding.EmbeddingStore;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.ApplicationContext;
 
 import java.util.List;
 
@@ -53,7 +54,7 @@ public abstract class EmbeddingStoreAutoConfigurationIT {
                     String id = embeddingStore.add(embedding, segment);
                     assertThat(id).isNotBlank();
 
-                    awaitUntilPersisted();
+                    awaitUntilPersisted(context);
 
                     List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
                     assertThat(relevant).hasSize(1);
@@ -82,7 +83,7 @@ public abstract class EmbeddingStoreAutoConfigurationIT {
                     String id = embeddingStore.add(embedding, segment);
                     assertThat(id).isNotBlank();
 
-                    awaitUntilPersisted();
+                    awaitUntilPersisted(context);
 
                     List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
                     assertThat(relevant).hasSize(1);
@@ -95,7 +96,7 @@ public abstract class EmbeddingStoreAutoConfigurationIT {
                 });
     }
 
-    protected void awaitUntilPersisted() {
+    protected void awaitUntilPersisted(ApplicationContext context) {
 
     }
 }

--- a/langchian4j-elasticsearch-spring-boot-starter/pom.xml
+++ b/langchian4j-elasticsearch-spring-boot-starter/pom.xml
@@ -14,6 +14,26 @@
     <name>LangChain4j Spring Boot starter for Elasticsearch</name>
     <packaging>jar</packaging>
 
+    <properties>
+        <!-- For tests only -->
+        <elastic.version>8.14.3</elastic.version>
+        <!-- You can run the tests using
+        # Elasticsearch Cloud
+        mvn verify -DELASTICSEARCH_URL=https://URL.elastic-cloud.com -DELASTICSEARCH_API_KEY=THE_KEY
+        # Elasticsearch running already Locally with a BASE64 encoded SSL CA Certificate
+        mvn verify -DELASTICSEARCH_URL=https://localhost:9200 -DELASTICSEARCH_PASSWORD=changeme -DELASTICSEARCH_CA_CERTIFICATE=BASE64-CONTENT
+        # Elasticsearch started by Testcontainers
+        mvn verify
+        # Elasticsearch started by Testcontainers with a specific password
+        mvn verify -DELASTICSEARCH_PASSWORD=changeme
+        -->
+        <ELASTICSEARCH_URL />
+        <ELASTICSEARCH_API_KEY />
+        <ELASTICSEARCH_USERNAME />
+        <ELASTICSEARCH_PASSWORD>changeme</ELASTICSEARCH_PASSWORD>
+        <ELASTICSEARCH_CA_CERTIFICATE />
+    </properties>
+
     <dependencies>
 
         <dependency>
@@ -86,4 +106,28 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <ELASTICSEARCH_URL>${ELASTICSEARCH_URL}</ELASTICSEARCH_URL>
+                        <ELASTICSEARCH_API_KEY>${ELASTICSEARCH_API_KEY}</ELASTICSEARCH_API_KEY>
+                        <ELASTICSEARCH_USERNAME>${ELASTICSEARCH_USERNAME}</ELASTICSEARCH_USERNAME>
+                        <ELASTICSEARCH_PASSWORD>${ELASTICSEARCH_PASSWORD}</ELASTICSEARCH_PASSWORD>
+                        <ELASTICSEARCH_CA_CERTIFICATE>${ELASTICSEARCH_CA_CERTIFICATE}</ELASTICSEARCH_CA_CERTIFICATE>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/langchian4j-elasticsearch-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/elasticsearch/spring/ElasticsearchClientHelper.java
+++ b/langchian4j-elasticsearch-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/elasticsearch/spring/ElasticsearchClientHelper.java
@@ -1,0 +1,128 @@
+package dev.langchain4j.store.embedding.elasticsearch.spring;
+
+import org.apache.http.Header;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.ssl.SSLContexts;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.io.ByteArrayInputStream;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+
+/**
+ * This class simply helps create a Rest Client instance
+ */
+class ElasticsearchClientHelper {
+
+    private static final Logger log = LoggerFactory.getLogger(ElasticsearchClientHelper.class);
+
+    /**
+     * Create an Elasticsearch Rest Client and test that it's running.
+     *
+     * @param address           the server url, like <a href="https://localhost:9200">https://localhost:9200</a>
+     * @param apiKey            the API key if any. If null, we will be using login/password
+     * @param username          the username to use if apiKey is not set.
+     * @param password          the password to use if apiKey is not set.
+     * @param checkCertificate  true if we want to check the certificate. If false, we won't check the certificate (tests only)
+     * @param caCertificate     the SSL CA certificate to use if provided, otherwise we will use the system ones
+     * @return the client instance
+     */
+    static RestClient getClient(String address, String apiKey, String username, String password,
+                                boolean checkCertificate, byte[] caCertificate) {
+        log.debug("Trying to connect to {}.", address);
+
+        // Create the low-level client
+        RestClientBuilder restClientBuilder = RestClient.builder(HttpHost.create(address));
+
+        if (!isNullOrBlank(apiKey)) {
+            restClientBuilder.setDefaultHeaders(new Header[]{
+                    new BasicHeader("Authorization", "Apikey " + apiKey)
+            });
+        } else {
+            final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            credentialsProvider.setCredentials(AuthScope.ANY,
+                    new UsernamePasswordCredentials(username, password));
+            restClientBuilder.setHttpClientConfigCallback(hcb -> hcb
+                    .setDefaultCredentialsProvider(credentialsProvider)
+                    .setSSLContext(getSSLContext(checkCertificate, caCertificate)));
+        }
+
+        return restClientBuilder.build();
+    }
+
+    /**
+     * @param checkCertificate  true if we want to check the certificate. If false, we won't check the certificate (tests only)
+     * @param caCertificate     the SSL CA certificate to use if provided, otherwise we will use the system ones
+     * @return the SSL Context
+     */
+    private static SSLContext getSSLContext(boolean checkCertificate, byte[] caCertificate) {
+        // If we don't want to check anything (not recommended for production)
+        if (!checkCertificate) {
+            return createTrustAllCertsContext();
+        }
+
+        // If we don't have a self-signed certificate
+        if (caCertificate == null) {
+            return null;
+        }
+
+        // If we have a self-signed certificate we need to check it against the fake Certificate Authority
+        return createContextFromCaCert(caCertificate);
+    }
+
+    /**
+     * Create an SSL Context from a Certificate
+     * @param certificate Certificate provided as a byte array
+     * @return the SSL Context
+     */
+    private static SSLContext createContextFromCaCert(byte[] certificate) {
+        try {
+            CertificateFactory factory = CertificateFactory.getInstance("X.509");
+            Certificate trustedCa = factory.generateCertificate(
+                    new ByteArrayInputStream(certificate)
+            );
+            KeyStore trustStore = KeyStore.getInstance("pkcs12");
+            trustStore.load(null, null);
+            trustStore.setCertificateEntry("ca", trustedCa);
+            SSLContextBuilder sslContextBuilder = SSLContexts.custom().loadTrustMaterial(trustStore, null);
+            return sslContextBuilder.build();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static final TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager() {
+        @Override public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+        @Override public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+        @Override public X509Certificate[] getAcceptedIssuers() { return null; }
+    }};
+
+    private static SSLContext createTrustAllCertsContext() {
+        try {
+            SSLContext sslContext = SSLContext.getInstance("SSL");
+            sslContext.init(null, trustAllCerts, new SecureRandom());
+            return sslContext;
+        } catch (NoSuchAlgorithmException | KeyManagementException e) {
+            throw new RuntimeException("Can not create the SSLContext", e);
+        }
+    }
+}

--- a/langchian4j-elasticsearch-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/elasticsearch/spring/ElasticsearchEmbeddingStoreAutoConfiguration.java
+++ b/langchian4j-elasticsearch-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/elasticsearch/spring/ElasticsearchEmbeddingStoreAutoConfiguration.java
@@ -1,14 +1,16 @@
 package dev.langchain4j.store.embedding.elasticsearch.spring;
 
-import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.store.embedding.elasticsearch.ElasticsearchEmbeddingStore;
+import org.elasticsearch.client.RestClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.lang.Nullable;
 
+import java.util.Base64;
 import java.util.Optional;
 
 import static dev.langchain4j.store.embedding.elasticsearch.spring.ElasticsearchEmbeddingStoreProperties.*;
@@ -18,21 +20,54 @@ import static dev.langchain4j.store.embedding.elasticsearch.spring.Elasticsearch
 @ConditionalOnProperty(prefix = PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
 public class ElasticsearchEmbeddingStoreAutoConfiguration {
 
+    private static final Logger log = LoggerFactory.getLogger(ElasticsearchEmbeddingStoreAutoConfiguration.class);
+
+    /**
+     * Create a bean for the Elasticsearch Rest Client if it does not exist yet
+     * but ideally this should be created before
+     * @param properties the properties
+     * @return a RestClient instance
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public RestClient elasticsearchRestClient(ElasticsearchEmbeddingStoreProperties properties) {
+        String serverUrl = Optional.ofNullable(properties.getServerUrl()).orElse(DEFAULT_SERVER_URL);
+        String username = Optional.ofNullable(properties.getUsername()).orElse(DEFAULT_USERNAME);
+        boolean checkSslCertificates = Optional.ofNullable(properties.getCheckSslCertificates()).orElse(true);
+
+        if (!checkSslCertificates) {
+            log.warn("disabling ssl checks is a bad practice in general and should be done ONLY in the context of tests.");
+        }
+
+        // If we have a self-signed certificate, we can provide it
+        byte[] caCertificate = null;
+        String caCertificateAsBase64String = properties.getCaCertificateAsBase64String();
+        if (caCertificateAsBase64String != null) {
+            caCertificate = Base64.getDecoder().decode(caCertificateAsBase64String);
+        }
+
+        log.debug("create RestClient running at [{}] with api key [{}], username [{}].",
+                serverUrl, properties.getApiKey(), username);
+
+        return ElasticsearchClientHelper.getClient(
+                serverUrl,
+                properties.getApiKey(),
+                username,
+                properties.getPassword(),
+                checkSslCertificates,
+                caCertificate);
+    }
+
     @Bean
     @ConditionalOnMissingBean
     public ElasticsearchEmbeddingStore elasticsearchEmbeddingStore(ElasticsearchEmbeddingStoreProperties properties,
-                                                                   @Nullable EmbeddingModel embeddingModel) {
-        String serverUrl = Optional.ofNullable(properties.getServerUrl()).orElse(DEFAULT_SERVER_URL);
+                                                                   RestClient elasticsearchRestClient) {
         String indexName = Optional.ofNullable(properties.getIndexName()).orElse(DEFAULT_INDEX_NAME);
-        Integer dimension = Optional.ofNullable(properties.getDimension()).orElseGet(() -> embeddingModel == null ? null : embeddingModel.dimension());
 
+        log.debug("create ElasticsearchEmbeddingStore on index [{}].", indexName);
         return ElasticsearchEmbeddingStore.builder()
-                .serverUrl(serverUrl)
-                .apiKey(properties.getApiKey())
-                .userName(properties.getUserName())
-                .password(properties.getPassword())
+                .restClient(elasticsearchRestClient)
                 .indexName(indexName)
-                .dimension(dimension)
                 .build();
     }
 }

--- a/langchian4j-elasticsearch-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/elasticsearch/spring/ElasticsearchEmbeddingStoreProperties.java
+++ b/langchian4j-elasticsearch-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/elasticsearch/spring/ElasticsearchEmbeddingStoreProperties.java
@@ -10,13 +10,15 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class ElasticsearchEmbeddingStoreProperties {
 
     static final String PREFIX = "langchain4j.elasticsearch";
-    static final String DEFAULT_SERVER_URL = "http://localhost:9200";
+    static final String DEFAULT_SERVER_URL = "https://localhost:9200";
     static final String DEFAULT_INDEX_NAME = "langchain4j-index";
+    static final String DEFAULT_USERNAME = "elastic";
 
     private String serverUrl;
     private String apiKey;
-    private String userName;
+    private String username;
     private String password;
     private String indexName;
-    private Integer dimension;
+    private Boolean checkSslCertificates;
+    private String caCertificateAsBase64String;
 }

--- a/langchian4j-elasticsearch-spring-boot-starter/src/test/java/dev/langchain4j/store/embedding/elasticsearch/spring/ElasticsearchTestContainerHelper.java
+++ b/langchian4j-elasticsearch-spring-boot-starter/src/test/java/dev/langchain4j/store/embedding/elasticsearch/spring/ElasticsearchTestContainerHelper.java
@@ -1,0 +1,99 @@
+package dev.langchain4j.store.embedding.elasticsearch.spring;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.InfoResponse;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import org.apache.commons.io.IOUtils;
+import org.elasticsearch.client.RestClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Properties;
+
+import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
+
+/**
+ * For this test, because Elasticsearch container might not be fast to start,
+ * devs could prefer having a cloud/local cluster running already.
+ * We try first to reach the cloud/local cluster and if not available, then start
+ * a container with Testcontainers.
+ */
+class ElasticsearchTestContainerHelper {
+
+    private static final Logger log = LoggerFactory.getLogger(ElasticsearchTestContainerHelper.class);
+
+    RestClient restClient;
+    ElasticsearchContainer elasticsearch;
+    String certAsBase64;
+
+    void startServices() throws IOException {
+        String url = System.getenv("ELASTICSEARCH_URL");
+        String apiKey = System.getenv("ELASTICSEARCH_API_KEY");
+        String username = System.getenv("ELASTICSEARCH_USERNAME");
+        String password = System.getenv("ELASTICSEARCH_PASSWORD");
+        certAsBase64 = System.getenv("ELASTICSEARCH_CA_CERTIFICATE");
+
+        if (isNotNullOrBlank(url)) {
+            // If we have a cloud URL, we use that
+            log.info("Starting Elasticsearch tests on [{}].", url);
+            byte[] caCertificate = null;
+            if (isNotNullOrBlank(certAsBase64)) {
+                caCertificate = Base64.getDecoder().decode(certAsBase64);
+            }
+            restClient = getClient(url, apiKey, username, password, true, caCertificate);
+        } else {
+            Properties props = new Properties();
+            props.load(ElasticsearchTestContainerHelper.class.getResourceAsStream("/version.properties"));
+            String version = props.getProperty("elastic.version");
+
+            // Start the container. This step might take some time...
+            log.info("Starting testcontainers with Elasticsearch [{}].", version);
+            elasticsearch = new ElasticsearchContainer(
+                    DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
+                            .withTag(version))
+                    .withPassword(password);
+            elasticsearch.start();
+            byte[] certAsBytes = elasticsearch.copyFileFromContainer(
+                    "/usr/share/elasticsearch/config/certs/http_ca.crt",
+                    IOUtils::toByteArray);
+            certAsBase64 = Base64.getEncoder().encodeToString(certAsBytes);
+            restClient = getClient("https://" + elasticsearch.getHttpHostAddress(), null,
+                    "elastic", password, false, certAsBytes);
+        }
+    }
+
+    void stopServices() throws IOException {
+        if (restClient != null) {
+            restClient.close();
+        }
+        if (elasticsearch != null) {
+            elasticsearch.stop();
+        }
+    }
+
+    /**
+     * Create an Elasticsearch Rest Client and test that it's running.
+     *
+     * @param address           the server url, like <a href="https://localhost:9200">https://localhost:9200</a>
+     * @param apiKey            the API key if any. If null, we will be using login/password
+     * @param username          the username to use if apiKey is not set.
+     * @param password          the password to use if apiKey is not set.
+     * @param checkCertificate  true if we want to check the certificate. If false, we won't check the certificate (tests only)
+     * @param caCertificate     the SSL CA certificate to use if provided, otherwise we will use the system ones
+     * @return the client
+     */
+    private RestClient getClient(String address, String apiKey, String username, String password,
+                                 boolean checkCertificate, byte[] caCertificate) throws IOException {
+        RestClient restClient = ElasticsearchClientHelper.getClient(address, apiKey, username, password,
+                checkCertificate, caCertificate);
+        InfoResponse info = new ElasticsearchClient(new RestClientTransport(restClient, new JacksonJsonpMapper())).info();
+        log.info("Found Elasticsearch cluster version [{}] running at [{}].", info.version().number(), address);
+
+        return restClient;
+    }
+}

--- a/langchian4j-elasticsearch-spring-boot-starter/src/test/resources/version.properties
+++ b/langchian4j-elasticsearch-spring-boot-starter/src/test/resources/version.properties
@@ -1,0 +1,2 @@
+# For testing purpose. We use the same Elasticsearch version as the one defined in the pom.xml
+elastic.version=${elastic.version}

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tinylog.version>2.6.2</tinylog.version>
         <spring.boot.version>3.2.6</spring.boot.version>
-        <testcontainers.version>1.19.8</testcontainers.version>
+        <testcontainers.version>1.20.1</testcontainers.version>
         <tinylog.version>2.6.2</tinylog.version>
     </properties>
 


### PR DESCRIPTION
This new implementation expects to have an Elasticsearch Rest Client bean (recommended) or it will create it otherwise.

This updates brings:

* The support for the new way to implement the Elasticsearch embbeding store as we now pass a rest client instead of "just" properties (deprecated in https://github.com/langchain4j/langchain4j/pull/712)
* The removal of previously needed number of dimensions (deprecated in https://github.com/langchain4j/langchain4j/pull/712)
* We add a `checkSslCertificates` property which should be only used in tests.
* We add a `caCertificateAsBase64String` property which can be used in tests when using a self-signed certificate.

About tests:

* We don't disable security anymore as it's not a good practice. We should educate users instead.
* We don't wait anymore for 1s for documents to be available, but instead we call the refresh API to make the documents immediately visible. So we change the `awaitUntilPersisted()` method to `awaitUntilPersisted(ApplicationContext)` so we can fetch the Elasticsearch Rest Client bean.
* We allow testing against a running cluster (local/cloud) and set from the CLI the URL (`ELASTICSEARCH_URL`), api key (`ELASTICSEARCH_API_KEY`), username (`ELASTICSEARCH_USERNAME`) and password (`ELASTICSEARCH_PASSWORD`). Note that when running with a self-signed certificate, the BASE64 version of the CA should be provided (`ELASTICSEARCH_CA_CERTIFICATE`).
* We fetch the version of the cluster used to run the tests from the `pom.xml` file using `elastic.version` property.
* We upgrade testcontainers to 1.20.1