### PR TITLE
Add support for GitHub Modules

### DIFF
--- a/langchain4j-github-models-spring-boot-starter/pom.xml
+++ b/langchain4j-github-models-spring-boot-starter/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-spring</artifactId>
+        <version>0.35.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-github-models-spring-boot-starter</artifactId>
+    <name>LangChain4j Spring Boot starter for GitHub Models</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-github-models</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- needed to generate automatic metadata about available config properties -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+</project>

--- a/langchain4j-github-models-spring-boot-starter/src/main/java/dev/langchain4j/model/github/spring/AutoConfig.java
+++ b/langchain4j-github-models-spring-boot-starter/src/main/java/dev/langchain4j/model/github/spring/AutoConfig.java
@@ -1,0 +1,78 @@
+package dev.langchain4j.model.github.spring;
+
+import com.azure.core.http.ProxyOptions;
+import com.azure.core.util.Configuration;
+import dev.langchain4j.model.github.GitHubModelsChatModel;
+import dev.langchain4j.model.github.GitHubModelsEmbeddingModel;
+import dev.langchain4j.model.github.GitHubModelsStreamingChatModel;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.lang.Nullable;
+
+import java.time.Duration;
+
+@AutoConfiguration
+@EnableConfigurationProperties(Properties.class)
+public class AutoConfig {
+
+    @Bean
+    @ConditionalOnProperty(Properties.PREFIX + ".chat-model.github-token")
+    GitHubModelsChatModel gitHubModelsChatModel(Properties properties) {
+        ChatModelProperties chatModelProperties = properties.getChatModel();
+        GitHubModelsChatModel.Builder builder = GitHubModelsChatModel.builder()
+                .endpoint(chatModelProperties.getEndpoint())
+                .gitHubToken(chatModelProperties.getGitHubToken())
+                .modelName(chatModelProperties.getModelName())
+                .temperature(chatModelProperties.getTemperature())
+                .topP(chatModelProperties.getTopP())
+                .maxTokens(chatModelProperties.getMaxTokens())
+                .presencePenalty(chatModelProperties.getPresencePenalty())
+                .frequencyPenalty(chatModelProperties.getFrequencyPenalty())
+                .timeout(Duration.ofSeconds(chatModelProperties.getTimeout() == null ? 0 : chatModelProperties.getTimeout()))
+                .maxRetries(chatModelProperties.getMaxRetries())
+                .proxyOptions(ProxyOptions.fromConfiguration(Configuration.getGlobalConfiguration()))
+                .logRequestsAndResponses(chatModelProperties.getLogRequestsAndResponses() != null && chatModelProperties.getLogRequestsAndResponses());
+
+        return builder.build();
+    }
+
+    @Bean
+    @ConditionalOnProperty(Properties.PREFIX + ".streaming-chat-model.github-token")
+    GitHubModelsStreamingChatModel gitHubModelsStreamingChatModel(Properties properties) {
+        ChatModelProperties chatModelProperties = properties.getStreamingChatModel();
+        GitHubModelsStreamingChatModel.Builder builder = GitHubModelsStreamingChatModel.builder()
+                .endpoint(chatModelProperties.getEndpoint())
+                .gitHubToken(chatModelProperties.getGitHubToken())
+                .modelName(chatModelProperties.getModelName())
+                .temperature(chatModelProperties.getTemperature())
+                .topP(chatModelProperties.getTopP())
+                .stop(chatModelProperties.getStop())
+                .maxTokens(chatModelProperties.getMaxTokens())
+                .presencePenalty(chatModelProperties.getPresencePenalty())
+                .frequencyPenalty(chatModelProperties.getFrequencyPenalty())
+                .timeout(Duration.ofSeconds(chatModelProperties.getTimeout() == null ? 0 : chatModelProperties.getTimeout()))
+                .proxyOptions(ProxyOptions.fromConfiguration(Configuration.getGlobalConfiguration()))
+                .logRequestsAndResponses(chatModelProperties.getLogRequestsAndResponses() != null && chatModelProperties.getLogRequestsAndResponses());
+
+        return builder.build();
+    }
+
+    @Bean
+    @ConditionalOnProperty({Properties.PREFIX + ".embedding-model.github-token"})
+    GitHubModelsEmbeddingModel openAiEmbeddingModelByApiKey(Properties properties) {
+        EmbeddingModelProperties embeddingModelProperties = properties.getEmbeddingModel();
+        GitHubModelsEmbeddingModel.Builder builder = GitHubModelsEmbeddingModel.builder()
+                .endpoint(embeddingModelProperties.getEndpoint())
+                .gitHubToken(embeddingModelProperties.getGitHubToken())
+                .modelName(embeddingModelProperties.getModelName())
+                .maxRetries(embeddingModelProperties.getMaxRetries())
+                .timeout(Duration.ofSeconds(embeddingModelProperties.getTimeout() == null ? 0 : embeddingModelProperties.getTimeout()))
+                .proxyOptions(ProxyOptions.fromConfiguration(Configuration.getGlobalConfiguration()))
+                .logRequestsAndResponses(embeddingModelProperties.getLogRequestsAndResponses() != null && embeddingModelProperties.getLogRequestsAndResponses());
+
+        return builder.build();
+    }
+}

--- a/langchain4j-github-models-spring-boot-starter/src/main/java/dev/langchain4j/model/github/spring/ChatModelProperties.java
+++ b/langchain4j-github-models-spring-boot-starter/src/main/java/dev/langchain4j/model/github/spring/ChatModelProperties.java
@@ -1,0 +1,133 @@
+package dev.langchain4j.model.github.spring;
+
+import java.util.List;
+
+class ChatModelProperties {
+
+    private String endpoint;
+    private String gitHubToken;
+    private String modelName;
+    private Double temperature;
+    private Double topP;
+    private Integer maxTokens;
+    private Double presencePenalty;
+    private Double frequencyPenalty;
+    private String responseFormat;
+    private Integer seed;
+    private List<String> stop;
+    private Integer timeout;
+    private Integer maxRetries;
+    private Boolean logRequestsAndResponses;
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public String getGitHubToken() {
+        return gitHubToken;
+    }
+
+    public void setGitHubToken(String gitHubToken) {
+        this.gitHubToken = gitHubToken;
+    }
+
+    public String getModelName() {
+        return modelName;
+    }
+
+    public void setModelName(String modelName) {
+        this.modelName = modelName;
+    }
+
+    public Double getTemperature() {
+        return temperature;
+    }
+
+    public void setTemperature(Double temperature) {
+        this.temperature = temperature;
+    }
+
+    public Double getTopP() {
+        return topP;
+    }
+
+    public void setTopP(Double topP) {
+        this.topP = topP;
+    }
+
+    public Integer getMaxTokens() {
+        return maxTokens;
+    }
+
+    public void setMaxTokens(Integer maxTokens) {
+        this.maxTokens = maxTokens;
+    }
+
+    public Double getPresencePenalty() {
+        return presencePenalty;
+    }
+
+    public void setPresencePenalty(Double presencePenalty) {
+        this.presencePenalty = presencePenalty;
+    }
+
+    public Double getFrequencyPenalty() {
+        return frequencyPenalty;
+    }
+
+    public void setFrequencyPenalty(Double frequencyPenalty) {
+        this.frequencyPenalty = frequencyPenalty;
+    }
+
+    public String getResponseFormat() {
+        return responseFormat;
+    }
+
+    public void setResponseFormat(String responseFormat) {
+        this.responseFormat = responseFormat;
+    }
+
+    public Integer getSeed() {
+        return seed;
+    }
+
+    public void setSeed(Integer seed) {
+        this.seed = seed;
+    }
+
+    public List<String> getStop() {
+        return stop;
+    }
+
+    public void setStop(List<String> stop) {
+        this.stop = stop;
+    }
+
+    public Integer getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(Integer timeout) {
+        this.timeout = timeout;
+    }
+
+    public Integer getMaxRetries() {
+        return maxRetries;
+    }
+
+    public void setMaxRetries(Integer maxRetries) {
+        this.maxRetries = maxRetries;
+    }
+
+    public Boolean getLogRequestsAndResponses() {
+        return logRequestsAndResponses;
+    }
+
+    public void setLogRequestsAndResponses(Boolean logRequestsAndResponses) {
+        this.logRequestsAndResponses = logRequestsAndResponses;
+    }
+}

--- a/langchain4j-github-models-spring-boot-starter/src/main/java/dev/langchain4j/model/github/spring/EmbeddingModelProperties.java
+++ b/langchain4j-github-models-spring-boot-starter/src/main/java/dev/langchain4j/model/github/spring/EmbeddingModelProperties.java
@@ -1,0 +1,68 @@
+package dev.langchain4j.model.github.spring;
+
+class EmbeddingModelProperties {
+
+    private String endpoint;
+    private String gitHubToken;
+    private String modelName;
+    private Integer dimensions;
+    private Integer timeout;
+    private Integer maxRetries;
+    private Boolean logRequestsAndResponses;
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public String getGitHubToken() {
+        return gitHubToken;
+    }
+
+    public void setGitHubToken(String gitHubToken) {
+        this.gitHubToken = gitHubToken;
+    }
+
+    public String getModelName() {
+        return modelName;
+    }
+
+    public void setModelName(String modelName) {
+        this.modelName = modelName;
+    }
+
+    public Integer getDimensions() {
+        return dimensions;
+    }
+
+    public void setDimensions(Integer dimensions) {
+        this.dimensions = dimensions;
+    }
+
+    public Integer getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(Integer timeout) {
+        this.timeout = timeout;
+    }
+
+    public Integer getMaxRetries() {
+        return maxRetries;
+    }
+
+    public void setMaxRetries(Integer maxRetries) {
+        this.maxRetries = maxRetries;
+    }
+
+    public Boolean getLogRequestsAndResponses() {
+        return logRequestsAndResponses;
+    }
+
+    public void setLogRequestsAndResponses(Boolean logRequestsAndResponses) {
+        this.logRequestsAndResponses = logRequestsAndResponses;
+    }
+}

--- a/langchain4j-github-models-spring-boot-starter/src/main/java/dev/langchain4j/model/github/spring/Properties.java
+++ b/langchain4j-github-models-spring-boot-starter/src/main/java/dev/langchain4j/model/github/spring/Properties.java
@@ -1,0 +1,43 @@
+package dev.langchain4j.model.github.spring;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+@ConfigurationProperties(prefix = Properties.PREFIX)
+public class Properties {
+
+    static final String PREFIX = "langchain4j.github-models";
+
+    @NestedConfigurationProperty
+    private ChatModelProperties chatModel;
+
+    @NestedConfigurationProperty
+    private ChatModelProperties streamingChatModel;
+
+    @NestedConfigurationProperty
+    private EmbeddingModelProperties embeddingModel;
+
+    public ChatModelProperties getChatModel() {
+        return chatModel;
+    }
+
+    public void setChatModel(ChatModelProperties chatModel) {
+        this.chatModel = chatModel;
+    }
+
+    public ChatModelProperties getStreamingChatModel() {
+        return streamingChatModel;
+    }
+
+    public void setStreamingChatModel(ChatModelProperties streamingChatModel) {
+        this.streamingChatModel = streamingChatModel;
+    }
+
+    public EmbeddingModelProperties getEmbeddingModel() {
+        return embeddingModel;
+    }
+
+    public void setEmbeddingModel(EmbeddingModelProperties embeddingModel) {
+        this.embeddingModel = embeddingModel;
+    }
+}

--- a/langchain4j-github-models-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/langchain4j-github-models-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.langchain4j.model.github.spring.AutoConfig

--- a/langchain4j-github-models-spring-boot-starter/src/test/java/dev/langchain4j/model/github/spring/AutoConfigIT.java
+++ b/langchain4j-github-models-spring-boot-starter/src/test/java/dev/langchain4j/model/github/spring/AutoConfigIT.java
@@ -1,0 +1,107 @@
+package dev.langchain4j.model.github.spring;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.StreamingResponseHandler;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.github.GitHubModelsChatModel;
+import dev.langchain4j.model.github.GitHubModelsEmbeddingModel;
+import dev.langchain4j.model.github.GitHubModelsStreamingChatModel;
+import dev.langchain4j.model.github.spring.AutoConfig;
+import dev.langchain4j.model.image.ImageModel;
+import dev.langchain4j.model.output.Response;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AutoConfigIT {
+
+    private static final String GITHUB_TOKEN = System.getenv("GITHUB_TOKEN");
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(AutoConfig.class));
+
+    @ParameterizedTest(name = "Model name: {0}")
+    @CsvSource({
+            "gpt-4o-mini",
+            "gpt-4o"
+    })
+    void should_provide_chat_model(String modelName) {
+        contextRunner
+                .withPropertyValues(
+                        "langchain4j.github-models.chat-model.github-token=" + GITHUB_TOKEN,
+                        "langchain4j.github-models.chat-model.model-name=" + modelName,
+                        "langchain4j.github-models.chat-model.max-tokens=20"
+                )
+                .run(context -> {
+
+                    ChatLanguageModel chatLanguageModel = context.getBean(ChatLanguageModel.class);
+                    assertThat(chatLanguageModel).isInstanceOf(GitHubModelsChatModel.class);
+                    assertThat(chatLanguageModel.generate("What is the capital of France?")).contains("Paris");
+                    assertThat(context.getBean(GitHubModelsChatModel.class)).isSameAs(chatLanguageModel);
+                });
+    }
+
+    @ParameterizedTest(name = "Model name: {0}")
+    @CsvSource({
+            "gpt-4o-mini",
+            "gpt-4o"
+    })
+    void should_provide_streaming_chat_model(String modelName) {
+        contextRunner
+                .withPropertyValues(
+                        "langchain4j.github-models.streaming-chat-model.github-token=" + GITHUB_TOKEN,
+                        "langchain4j.github-models.streaming-chat-model.model-name=" + modelName,
+                        "langchain4j.github-models.streaming-chat-model.max-tokens=20",
+                        "langchain4j.github-models.streaming-chat-model.timeout=60"
+                )
+                .run(context -> {
+
+                    StreamingChatLanguageModel streamingChatLanguageModel = context.getBean(StreamingChatLanguageModel.class);
+                    assertThat(streamingChatLanguageModel).isInstanceOf(GitHubModelsStreamingChatModel.class);
+                    CompletableFuture<Response<AiMessage>> future = new CompletableFuture<>();
+                    streamingChatLanguageModel.generate("What is the capital of France?", new StreamingResponseHandler<AiMessage>() {
+
+                        @Override
+                        public void onNext(String token) {
+                        }
+
+                        @Override
+                        public void onComplete(Response<AiMessage> response) {
+                            future.complete(response);
+                        }
+
+                        @Override
+                        public void onError(Throwable error) {
+                        }
+                    });
+                    Response<AiMessage> response = future.get(60, SECONDS);
+                    assertThat(response.content().text()).contains("Paris");
+
+                    assertThat(context.getBean(GitHubModelsStreamingChatModel.class)).isSameAs(streamingChatLanguageModel);
+                });
+    }
+
+    @Test
+    void should_provide_embedding_model() {
+        contextRunner
+                .withPropertyValues("langchain4j.github-models.embedding-model.github-token=" + GITHUB_TOKEN,
+                        "langchain4j.github-models.embedding-model.model-name=" + "text-embedding-3-small")
+                .run(context -> {
+
+                    EmbeddingModel embeddingModel = context.getBean(EmbeddingModel.class);
+                    assertThat(embeddingModel).isInstanceOf(GitHubModelsEmbeddingModel.class);
+                    assertThat(embeddingModel.embed("hi").content().dimension()).isEqualTo(1536);
+
+                    assertThat(context.getBean(GitHubModelsEmbeddingModel.class)).isSameAs(embeddingModel);
+                });
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <module>langchain4j-azure-ai-search-spring-boot-starter</module>
         <module>langchain4j-azure-open-ai-spring-boot-starter</module>
         <module>langchain4j-voyage-ai-spring-boot-starter</module>
+        <module>langchain4j-github-models-spring-boot-starter</module>
 
         <module>langchain4j-vertex-ai-gemini-spring-boot-starter</module>
         <module>langchain4j-elasticsearch-spring-boot-starter</module>


### PR DESCRIPTION
This adds support for GitHub Modules, which were added in LangChain4J with https://github.com/langchain4j/langchain4j/pull/1807

Once this is merged, I'll update the LangChain4J documentation accordingly.