### PR TITLE
Change the name of the AzureOpenAiTokenizer Bean

### DIFF
--- a/langchain4j-azure-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/azure/openai/spring/AutoConfig.java
+++ b/langchain4j-azure-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/azure/openai/spring/AutoConfig.java
@@ -154,7 +154,7 @@ public class AutoConfig {
 
     @Bean
     @ConditionalOnMissingBean
-    AzureOpenAiTokenizer openAiTokenizer() {
+    AzureOpenAiTokenizer azureOpenAiTokenizer() {
         return new AzureOpenAiTokenizer();
     }
 }


### PR DESCRIPTION
Fix https://github.com/langchain4j/langchain4j/issues/1867

The Bean name is by default the method name, so by changing the method name we shouldn't have a clash anymore with openAiTokenizer. Also, this name makes more sense.