### PR TITLE
fix #1827 ComponentScan with SPEL will not parse

### DIFF
--- a/langchain4j-spring-boot-starter/src/main/java/dev/langchain4j/service/spring/AiServiceScannerProcessor.java
+++ b/langchain4j-spring-boot-starter/src/main/java/dev/langchain4j/service/spring/AiServiceScannerProcessor.java
@@ -1,15 +1,19 @@
 package dev.langchain4j.service.spring;
 
+import lombok.NonNull;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -17,50 +21,54 @@ import java.util.List;
 import java.util.Set;
 
 @Component
-public class AiServiceScannerProcessor implements BeanDefinitionRegistryPostProcessor {
+public class AiServiceScannerProcessor implements BeanDefinitionRegistryPostProcessor, EnvironmentAware {
+
+    private volatile Environment environment;
+
+    @Override
+    public void setEnvironment(@NonNull Environment environment) {
+        this.environment = environment;
+    }
 
     @Override
     public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
-        ClassPathAiServiceScanner classPathAiServiceScanner = new ClassPathAiServiceScanner(registry, false);
+        ClassPathAiServiceScanner scanner = new ClassPathAiServiceScanner(registry, false);
         Set<String> basePackages = getBasePackages((ConfigurableListableBeanFactory) registry);
-        for (String basePackage : basePackages) {
-            classPathAiServiceScanner.scan(basePackage);
-        }
+        scanner.scan(StringUtils.toStringArray(basePackages));
     }
 
     private Set<String> getBasePackages(ConfigurableListableBeanFactory beanFactory) {
         Set<String> basePackages = new LinkedHashSet<>();
 
+        // AutoConfiguration
         List<String> autoConfigPackages = AutoConfigurationPackages.get(beanFactory);
         basePackages.addAll(autoConfigPackages);
 
-        String[] beanNames = beanFactory.getBeanNamesForAnnotation(ComponentScan.class);
-        for (String beanName : beanNames) {
-            Class<?> beanClass = beanFactory.getType(beanName);
-            if (beanClass != null) {
-                ComponentScan componentScan = beanClass.getAnnotation(ComponentScan.class);
-                if (componentScan != null) {
-                    Collections.addAll(basePackages, componentScan.value());
-                    Collections.addAll(basePackages, componentScan.basePackages());
-                    for (Class<?> basePackageClass : componentScan.basePackageClasses()) {
-                        basePackages.add(basePackageClass.getPackage().getName());
-                    }
-                }
-            }
-        }
-
-        String[] applicationBeans = beanFactory.getBeanNamesForAnnotation(SpringBootApplication.class);
-        if (applicationBeans.length > 0) {
-            Class<?> applicationBeanClass = beanFactory.getType(applicationBeans[0]);
-            SpringBootApplication springBootApplication = AnnotationUtils.findAnnotation(applicationBeanClass, SpringBootApplication.class);
-            if (springBootApplication != null) {
-                Collections.addAll(basePackages, springBootApplication.scanBasePackages());
-                for (Class<?> aClass : springBootApplication.scanBasePackageClasses()) {
-                    basePackages.add(ClassUtils.getPackageName(aClass));
-                }
-            }
-        }
+        // ComponentScan
+        addComponentScanPackages(beanFactory, basePackages);
 
         return basePackages;
+    }
+
+    private void addComponentScanPackages(ConfigurableListableBeanFactory beanFactory, Set<String> collectedBasePackages) {
+        beanFactory.getBeansWithAnnotation(ComponentScan.class).forEach((beanName, instance) -> {
+            Set<ComponentScan> componentScans = AnnotatedElementUtils.getMergedRepeatableAnnotations(instance.getClass(), ComponentScan.class);
+            for (ComponentScan componentScan : componentScans) {
+                Set<String> basePackages = new LinkedHashSet<>();
+                String[] basePackagesArray = componentScan.basePackages();
+                for (String pkg : basePackagesArray) {
+                    String[] tokenized = StringUtils.tokenizeToStringArray(this.environment.resolvePlaceholders(pkg),
+                            ConfigurableApplicationContext.CONFIG_LOCATION_DELIMITERS);
+                    Collections.addAll(basePackages, tokenized);
+                }
+                for (Class<?> clazz : componentScan.basePackageClasses()) {
+                    basePackages.add(ClassUtils.getPackageName(clazz));
+                }
+                if (basePackages.isEmpty()) {
+                    basePackages.add(ClassUtils.getPackageName(instance.getClass()));
+                }
+                collectedBasePackages.addAll(basePackages);
+            }
+        });
     }
 }


### PR DESCRIPTION
fix ComponentScan basePackages with placeholders will not be parsed. 

Changes Made:
- Support for parsing @ComponentScan with placeholders
- Simplify the getBasePackages()

Relevant Links:
- https://github.com/langchain4j/langchain4j/issues/1827#issuecomment-2396952160