### PR TITLE
add AiServiceRegisteredEvent

### DIFF
--- a/langchain4j-spring-boot-starter/src/main/java/dev/langchain4j/service/spring/AiServicesAutoConfig.java
+++ b/langchain4j-spring-boot-starter/src/main/java/dev/langchain4j/service/spring/AiServicesAutoConfig.java
@@ -23,12 +23,10 @@ import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.annotation.Bean;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/langchain4j-spring-boot-starter/src/main/java/dev/langchain4j/service/spring/AiServicesAutoConfig.java
+++ b/langchain4j-spring-boot-starter/src/main/java/dev/langchain4j/service/spring/AiServicesAutoConfig.java
@@ -1,6 +1,8 @@
 package dev.langchain4j.service.spring;
 
 import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.agent.tool.ToolSpecifications;
 import dev.langchain4j.exception.IllegalConfigurationException;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
@@ -9,19 +11,27 @@ import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 import dev.langchain4j.model.moderation.ModerationModel;
 import dev.langchain4j.rag.RetrievalAugmentor;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import dev.langchain4j.service.spring.event.AiServiceRegisteredEvent;
 import org.springframework.beans.MutablePropertyValues;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.GenericBeanDefinition;
 import org.springframework.beans.factory.support.ManagedList;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.annotation.Bean;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static dev.langchain4j.exception.IllegalConfigurationException.illegalConfiguration;
 import static dev.langchain4j.internal.Exceptions.illegalArgument;
@@ -31,7 +41,14 @@ import static dev.langchain4j.service.spring.AiServiceWiringMode.AUTOMATIC;
 import static dev.langchain4j.service.spring.AiServiceWiringMode.EXPLICIT;
 import static java.util.Arrays.asList;
 
-public class AiServicesAutoConfig {
+public class AiServicesAutoConfig implements ApplicationEventPublisherAware {
+
+    private ApplicationEventPublisher eventPublisher;
+
+    @Override
+    public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+        this.eventPublisher = applicationEventPublisher;
+    }
 
     @Bean
     BeanFactoryPostProcessor aiServicesRegisteringBeanFactoryPostProcessor() {
@@ -47,12 +64,15 @@ public class AiServicesAutoConfig {
             String[] moderationModels = beanFactory.getBeanNamesForType(ModerationModel.class);
 
             Set<String> tools = new HashSet<>();
+            Map<String, ToolSpecification> toolSpecifications = new HashMap<>();
             for (String beanName : beanFactory.getBeanDefinitionNames()) {
                 try {
                     Class<?> beanClass = Class.forName(beanFactory.getBeanDefinition(beanName).getBeanClassName());
                     for (Method beanMethod : beanClass.getDeclaredMethods()) {
                         if (beanMethod.isAnnotationPresent(Tool.class)) {
-                            tools.add(beanName);
+                            if (tools.add(beanName)) {
+                                toolSpecifications.put(beanName, ToolSpecifications.toolSpecificationFrom(beanMethod));
+                            }
                         }
                     }
                 } catch (Exception e) {
@@ -70,7 +90,6 @@ public class AiServicesAutoConfig {
                 MutablePropertyValues propertyValues = aiServiceBeanDefinition.getPropertyValues();
 
                 AiService aiServiceAnnotation = aiServiceClass.getAnnotation(AiService.class);
-
                 addBeanReference(
                         ChatLanguageModel.class,
                         aiServiceAnnotation,
@@ -140,11 +159,13 @@ public class AiServicesAutoConfig {
                         "moderationModel",
                         propertyValues
                 );
-
+                AiServiceRegisteredEvent registeredEvent;
                 if (aiServiceAnnotation.wiringMode() == EXPLICIT) {
                     propertyValues.add("tools", toManagedList(asList(aiServiceAnnotation.tools())));
+                    registeredEvent = buildEvent(aiServiceClass, toolSpecifications, asList(aiServiceAnnotation.tools()));
                 } else if (aiServiceAnnotation.wiringMode() == AUTOMATIC) {
                     propertyValues.add("tools", toManagedList(tools));
+                    registeredEvent = buildEvent(aiServiceClass, toolSpecifications, tools);
                 } else {
                     throw illegalArgument("Unknown wiring mode: " + aiServiceAnnotation.wiringMode());
                 }
@@ -152,6 +173,10 @@ public class AiServicesAutoConfig {
                 BeanDefinitionRegistry registry = (BeanDefinitionRegistry) beanFactory;
                 registry.removeBeanDefinition(aiService);
                 registry.registerBeanDefinition(lowercaseFirstLetter(aiService), aiServiceBeanDefinition);
+
+                if (eventPublisher != null) {
+                    eventPublisher.publishEvent(registeredEvent);
+                }
             }
         };
     }
@@ -198,5 +223,14 @@ public class AiServicesAutoConfig {
             managedList.add(new RuntimeBeanReference(beanName));
         }
         return managedList;
+    }
+
+    private static AiServiceRegisteredEvent buildEvent(Class<?> aiServiceClass,
+                                                       Map<String, ToolSpecification> toolSpecifications,
+                                                       Collection<String> tools) {
+        return new AiServiceRegisteredEvent(aiServiceClass, aiServiceClass, tools.stream()
+                                                                                 .filter(toolSpecifications::containsKey)
+                                                                                 .map(toolSpecifications::get)
+                                                                                 .collect(Collectors.toList()));
     }
 }

--- a/langchain4j-spring-boot-starter/src/main/java/dev/langchain4j/service/spring/event/AiServiceRegisteredEvent.java
+++ b/langchain4j-spring-boot-starter/src/main/java/dev/langchain4j/service/spring/event/AiServiceRegisteredEvent.java
@@ -1,0 +1,26 @@
+package dev.langchain4j.service.spring.event;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import org.springframework.context.ApplicationEvent;
+
+import java.util.List;
+
+public class AiServiceRegisteredEvent extends ApplicationEvent {
+
+    private final Class<?> aiServiceClass;
+    private final List<ToolSpecification> toolSpecifications;
+
+    public AiServiceRegisteredEvent(Object source, Class<?> aiServiceClass, List<ToolSpecification> toolSpecifications) {
+        super(source);
+        this.aiServiceClass = aiServiceClass;
+        this.toolSpecifications = toolSpecifications;
+    }
+
+    public Class<?> getAiServiceClass() {
+        return aiServiceClass;
+    }
+
+    public List<ToolSpecification> getToolSpecifications() {
+        return toolSpecifications;
+    }
+}

--- a/langchain4j-spring-boot-starter/src/main/java/dev/langchain4j/service/spring/event/AiServiceRegisteredEventListener.java
+++ b/langchain4j-spring-boot-starter/src/main/java/dev/langchain4j/service/spring/event/AiServiceRegisteredEventListener.java
@@ -1,0 +1,6 @@
+package dev.langchain4j.service.spring.event;
+
+import org.springframework.context.ApplicationListener;
+
+public interface AiServiceRegisteredEventListener extends ApplicationListener<AiServiceRegisteredEvent> {
+}

--- a/langchain4j-spring-boot-starter/src/main/java/dev/langchain4j/service/spring/event/AiServiceRegisteredEventListener.java
+++ b/langchain4j-spring-boot-starter/src/main/java/dev/langchain4j/service/spring/event/AiServiceRegisteredEventListener.java
@@ -1,6 +1,0 @@
-package dev.langchain4j.service.spring.event;
-
-import org.springframework.context.ApplicationListener;
-
-public interface AiServiceRegisteredEventListener extends ApplicationListener<AiServiceRegisteredEvent> {
-}

--- a/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/withTools/AiServiceWithToolsApplication.java
+++ b/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/withTools/AiServiceWithToolsApplication.java
@@ -2,14 +2,17 @@ package dev.langchain4j.service.spring.mode.automatic.withTools;
 
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.service.spring.event.AiServiceRegisteredEvent;
-import dev.langchain4j.service.spring.event.AiServiceRegisteredEventListener;
+import dev.langchain4j.service.spring.mode.automatic.withTools.listener.AbstractApplicationListener;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Import;
 
 import java.util.List;
 
+@Import(AbstractApplicationListener.class)
 @SpringBootApplication
-class AiServiceWithToolsApplication implements AiServiceRegisteredEventListener {
+class AiServiceWithToolsApplication implements ApplicationListener<AiServiceRegisteredEvent> {
 
     public static void main(String[] args) {
         SpringApplication.run(AiServiceWithToolsApplication.class, args);

--- a/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/withTools/AiServiceWithToolsApplication.java
+++ b/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/withTools/AiServiceWithToolsApplication.java
@@ -1,12 +1,26 @@
 package dev.langchain4j.service.spring.mode.automatic.withTools;
 
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.service.spring.event.AiServiceRegisteredEvent;
+import dev.langchain4j.service.spring.event.AiServiceRegisteredEventListener;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import java.util.List;
+
 @SpringBootApplication
-class AiServiceWithToolsApplication {
+class AiServiceWithToolsApplication implements AiServiceRegisteredEventListener {
 
     public static void main(String[] args) {
         SpringApplication.run(AiServiceWithToolsApplication.class, args);
+    }
+
+    @Override
+    public void onApplicationEvent(AiServiceRegisteredEvent event) {
+        Class<?> aiServiceClass = event.getAiServiceClass();
+        List<ToolSpecification> toolSpecifications = event.getToolSpecifications();
+        for (int i = 0; i < toolSpecifications.size(); i++) {
+            System.out.printf("[%s]: [Tool-%s]: %s%n", aiServiceClass.getSimpleName(), i + 1, toolSpecifications.get(i));
+        }
     }
 }

--- a/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/withTools/AiServicesAutoConfigIT.java
+++ b/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/withTools/AiServicesAutoConfigIT.java
@@ -99,8 +99,9 @@ class AiServicesAutoConfigIT {
                  });
      }
 
-      void should_create_AI_service_with_tool_which_is_enhanced_by_spring_aop() {
-          contextRunner
+    @Test
+    void should_create_AI_service_with_tool_which_is_enhanced_by_spring_aop() {
+        contextRunner
                 .withPropertyValues(
                         "langchain4j.open-ai.chat-model.api-key=" + OPENAI_API_KEY,
                         "langchain4j.open-ai.chat-model.temperature=0.0",

--- a/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/withTools/listener/AbstractApplicationListener.java
+++ b/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/withTools/listener/AbstractApplicationListener.java
@@ -1,0 +1,32 @@
+package dev.langchain4j.service.spring.mode.automatic.withTools.listener;
+
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AbstractApplicationListener<E extends ApplicationEvent> implements ApplicationListener<E> {
+
+    private boolean eventReceived = false;
+    private final List<E> receivedEvents = new ArrayList<>();
+
+    @Override
+    public void onApplicationEvent(E event) {
+        eventReceived = true;
+        receivedEvents.add(event);
+    }
+
+    public List<E> getReceivedEvents() {
+        return receivedEvents;
+    }
+
+    public boolean isEventReceived() {
+        return eventReceived;
+    }
+
+    public void reset() {
+        eventReceived = false;
+        receivedEvents.clear();
+    }
+}

--- a/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/withTools/listener/AiServiceRegisteredEventListener.java
+++ b/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/withTools/listener/AiServiceRegisteredEventListener.java
@@ -1,0 +1,7 @@
+package dev.langchain4j.service.spring.mode.automatic.withTools.listener;
+
+import dev.langchain4j.service.spring.event.AiServiceRegisteredEvent;
+import org.springframework.stereotype.Component;
+@Component
+public class AiServiceRegisteredEventListener extends AbstractApplicationListener<AiServiceRegisteredEvent> {
+}


### PR DESCRIPTION
Publish a Spring Event after registering the AiService Bean in AiServicesAutoConfig.
This event contains the AiService class and its corresponding tools description information.

Once a user implements the AiServiceRegisteredEventListener to listen for this event, they can receive the event during the Spring Boot startup phase and handle their business logic as needed.


Issues link: https://github.com/langchain4j/langchain4j/issues/2112