### PR TITLE
Fix #2133 Spring boot starter breaks configuration classes

### DIFF
--- a/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/Issue2133/TestAutowireAiServiceApplication.java
+++ b/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/Issue2133/TestAutowireAiServiceApplication.java
@@ -1,0 +1,24 @@
+package dev.langchain4j.service.spring.mode.automatic.Issue2133;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * @author: qing
+ * @Date: 2024/11/20
+ */
+@SpringBootApplication
+public class TestAutowireAiServiceApplication {
+
+    @Autowired
+    TestAutowireConfiguration testAutowireConfiguration;
+
+    public static void main(String[] args) {
+        SpringApplication.run(TestAutowireAiServiceApplication.class, args);
+    }
+
+    TestAutowireConfiguration getConfiguration() {
+        return testAutowireConfiguration;
+    }
+}

--- a/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/Issue2133/TestAutowireClassAiServiceIT.java
+++ b/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/Issue2133/TestAutowireClassAiServiceIT.java
@@ -1,0 +1,28 @@
+package dev.langchain4j.service.spring.mode.automatic.Issue2133;
+
+import dev.langchain4j.service.spring.AiServicesAutoConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class TestAutowireClassAiServiceIT {
+
+    ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(AiServicesAutoConfig.class));
+
+    @Test
+    void should_get_configuration_class() {
+        contextRunner
+                .withUserConfiguration(TestAutowireAiServiceApplication.class)
+                .withBean(TestAutowireConfiguration.class)
+                .run(context -> {
+                    // given
+                    TestAutowireAiServiceApplication application = context.getBean(TestAutowireAiServiceApplication.class);
+
+                    // should get the configuration class
+                    assertNotNull(application.getConfiguration(), "TestConfiguration class should be not null");
+                });
+    }
+}

--- a/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/Issue2133/TestAutowireConfiguration.java
+++ b/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/Issue2133/TestAutowireConfiguration.java
@@ -1,0 +1,11 @@
+package dev.langchain4j.service.spring.mode.automatic.Issue2133;
+
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author: qing
+ * @Date: 2024/11/20
+ */
+@Configuration
+class TestAutowireConfiguration {
+}


### PR DESCRIPTION
Fixes https://github.com/langchain4j/langchain4j/issues/2133

The problem is `beanfactory.getBeanswithanNotation()`. It creates an instance of the Bean in advance.

https://github.com/langchain4j/langchain4j-spring/blob/405fddafbcf8c3463c7211dc82b7c5887f9531c6/langchain4j-spring-boot-starter/src/main/java/dev/langchain4j/service/spring/AiServiceScannerProcessor.java#L49