### PR TITLE
Add Chroma Spring Boot Starter

### DIFF
--- a/langchain4j-chroma-spring-boot-starter/pom.xml
+++ b/langchain4j-chroma-spring-boot-starter/pom.xml
@@ -1,0 +1,100 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <repositories>
+    <repository>
+        <id>central</id>
+        <name>Maven Central Repository</name>
+        <url>https://repo.maven.apache.org/maven2</url>
+        <releases>
+            <enabled>true</enabled>
+        </releases>
+        <snapshots>
+            <enabled>false</enabled>
+        </snapshots>
+    </repository>
+    </repositories>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-spring</artifactId>
+        <version>0.37.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>langchain4j-chroma-spring-boot-starter</artifactId>
+    <name>LangChain4j Spring Boot starter for Chroma </name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <!-- langchain4j-chroma -->
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-chroma</artifactId>
+        </dependency>
+
+       <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        
+        
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- should be listed before spring-boot-configuration-processor -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- needed to generate automatic metadata about available config properties -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-spring-boot-tests</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>1.18.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>tinylog-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>slf4j-tinylog</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/langchain4j-chroma-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreAutoConfiguration.java
+++ b/langchain4j-chroma-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreAutoConfiguration.java
@@ -1,0 +1,29 @@
+package dev.langchain4j.store.embedding.chroma.spring;
+
+import dev.langchain4j.store.embedding.chroma.ChromaEmbeddingStore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import java.util.Optional;
+import java.time.Duration;
+import static dev.langchain4j.store.embedding.chroma.spring.ChromaEmbeddingStoreProperties.*;
+
+@AutoConfiguration
+@ConditionalOnProperty(prefix = "langchain4j.chroma", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class ChromaEmbeddingStoreAutoConfiguration {
+
+    public ChromaEmbeddingStore chromaEmbeddingStore(ChromaEmbeddingStoreProperties properties) {
+        String baseUrl = Optional.ofNullable(properties.getBaseUrl()).orElse(DEFAULT_BASE_URL);
+        String collectionName = Optional.ofNullable(properties.getCollectionName()).orElse(DEFAULT_COLLECTION_NAME);
+        Duration timeout = Optional.ofNullable(properties.getTimeout()).orElse(DEFAULT_TIMEOUT);
+        
+        return ChromaEmbeddingStore.builder()
+                .baseUrl(baseUrl)
+                .collectionName(collectionName)
+                .timeout(timeout)
+                .logRequests(properties.getLogRequests())
+                .logResponses(properties.getLogResponses())
+                .build();
+    }
+}

--- a/langchain4j-chroma-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreProperties.java
+++ b/langchain4j-chroma-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreProperties.java
@@ -1,0 +1,24 @@
+package dev.langchain4j.store.embedding.chroma.spring;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = ChromaEmbeddingStoreProperties.PREFIX)
+public class ChromaEmbeddingStoreProperties {
+
+    static final String PREFIX = "langchain4j.chroma";
+    static final String DEFAULT_BASE_URL = "http://localhost:8000";
+    static final String DEFAULT_COLLECTION_NAME = "default";
+    static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
+
+    private String baseUrl;
+    private String collectionName;
+    private Duration timeout;
+    private Boolean logRequests;
+    private Boolean logResponses;
+}

--- a/langchain4j-chroma-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/langchain4j-chroma-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.langchain4j.store.embedding.chroma.spring.ChromaEmbeddingStoreAutoConfiguration

--- a/langchain4j-chroma-spring-boot-starter/src/test/java/ChromaEmbeddingStoreAutoConfigurationIT.java
+++ b/langchain4j-chroma-spring-boot-starter/src/test/java/ChromaEmbeddingStoreAutoConfigurationIT.java
@@ -1,0 +1,55 @@
+package dev.langchain4j.store.embedding.chroma.spring;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.chroma.ChromaEmbeddingStore;
+import dev.langchain4j.store.embedding.spring.EmbeddingStoreAutoConfigurationIT;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+class ChromaEmbeddingStoreAutoConfigurationIT extends EmbeddingStoreAutoConfigurationIT {
+
+    // Define a Testcontainers instance for Chroma
+    static GenericContainer<?> chromaContainer = new GenericContainer<>("chroma-core:latest")
+            .withExposedPorts(8000) // Chroma typically runs on port 8000
+            .waitingFor(Wait.forHttp("/").forStatusCode(200)); // Wait until Chroma service is ready
+
+    @BeforeAll
+    static void beforeAll() {
+        chromaContainer.start();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        chromaContainer.stop();
+    }
+
+    @Override
+    protected Class<?> autoConfigurationClass() {
+        return ChromaEmbeddingStoreAutoConfiguration.class;
+    }
+
+    @Override
+    protected Class<? extends EmbeddingStore<TextSegment>> embeddingStoreClass() {
+        return ChromaEmbeddingStore.class;
+    }
+
+    @Override
+    protected String[] properties() {
+        return new String[]{
+                "langchain4j.chroma.base-url=http://" + chromaContainer.getHost() + ":" + chromaContainer.getMappedPort(8000),
+                "langchain4j.chroma.collection-name=test-collection",
+                "langchain4j.chroma.timeout=5s",
+                "langchain4j.chroma.log-requests=true",
+                "langchain4j.chroma.log-responses=false"
+        };
+    }
+
+    @Override
+    protected String dimensionPropertyKey() {
+        // Chroma doesn't require a dimension property; return null or a placeholder key if needed
+        return "langchain4j.chroma.dimension";
+    }
+}


### PR DESCRIPTION
This PR adds a Spring Boot Starter for the `langchain4j-chroma` module. It provides:
- Auto-configuration for `ChromaEmbeddingStore`.
- Configuration properties for easy customization.
- Integration with Spring Boot's dependency injection.

Key files:
- `ChromaEmbeddingStoreAutoConfiguration` for auto-configuration.
- `ChromaProperties` for user-defined properties.
- Test cases for configuration and integration.

Please let me know if there are any changes required. Thanks!