### PR TITLE
Autowire all available `ChatModelListener`s

### DIFF
--- a/langchain4j-anthropic-spring-boot-starter/src/main/java/dev/langchain4j/anthropic/spring/AutoConfig.java
+++ b/langchain4j-anthropic-spring-boot-starter/src/main/java/dev/langchain4j/anthropic/spring/AutoConfig.java
@@ -2,6 +2,8 @@ package dev.langchain4j.anthropic.spring;
 
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
 import dev.langchain4j.model.anthropic.AnthropicStreamingChatModel;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -15,7 +17,7 @@ public class AutoConfig {
 
     @Bean
     @ConditionalOnProperty(PREFIX + ".chat-model.api-key")
-    AnthropicChatModel anthropicChatModel(Properties properties) {
+    AnthropicChatModel anthropicChatModel(Properties properties, ObjectProvider<ChatModelListener> listeners) {
         ChatModelProperties chatModelProperties = properties.getChatModel();
         return AnthropicChatModel.builder()
                 .baseUrl(chatModelProperties.getBaseUrl())
@@ -31,12 +33,14 @@ public class AutoConfig {
                 .maxRetries(chatModelProperties.getMaxRetries())
                 .logRequests(chatModelProperties.getLogRequests())
                 .logResponses(chatModelProperties.getLogResponses())
+                .listeners(listeners.orderedStream().toList())
                 .build();
     }
 
     @Bean
     @ConditionalOnProperty(PREFIX + ".streaming-chat-model.api-key")
-    AnthropicStreamingChatModel anthropicStreamingChatModel(Properties properties) {
+    AnthropicStreamingChatModel anthropicStreamingChatModel(Properties properties,
+                                                            ObjectProvider<ChatModelListener> listeners) {
         ChatModelProperties chatModelProperties = properties.getStreamingChatModel();
         return AnthropicStreamingChatModel.builder()
                 .baseUrl(chatModelProperties.getBaseUrl())
@@ -51,6 +55,7 @@ public class AutoConfig {
                 .timeout(chatModelProperties.getTimeout())
                 .logRequests(chatModelProperties.getLogRequests())
                 .logResponses(chatModelProperties.getLogResponses())
+                .listeners(listeners.orderedStream().toList())
                 .build();
     }
 }

--- a/langchain4j-azure-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/azure/openai/spring/AutoConfig.java
+++ b/langchain4j-azure-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/azure/openai/spring/AutoConfig.java
@@ -4,6 +4,8 @@ import com.azure.core.http.ProxyOptions;
 import com.azure.core.util.Configuration;
 import dev.langchain4j.model.Tokenizer;
 import dev.langchain4j.model.azure.*;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -19,17 +21,19 @@ public class AutoConfig {
 
     @Bean
     @ConditionalOnProperty(Properties.PREFIX + ".chat-model.api-key")
-    AzureOpenAiChatModel openAiChatModelByAPIKey(Properties properties) {
-        return openAiChatModel(properties);
+    AzureOpenAiChatModel openAiChatModelByAPIKey(Properties properties,
+                                                 ObjectProvider<ChatModelListener> listeners) {
+        return openAiChatModel(properties, listeners);
     }
 
     @Bean
     @ConditionalOnProperty(Properties.PREFIX + ".chat-model.non-azure-api-key")
-    AzureOpenAiChatModel openAiChatModelByNonAzureApiKey(Properties properties) {
-        return openAiChatModel(properties);
+    AzureOpenAiChatModel openAiChatModelByNonAzureApiKey(Properties properties,
+                                                         ObjectProvider<ChatModelListener> listeners) {
+        return openAiChatModel(properties, listeners);
     }
 
-    AzureOpenAiChatModel openAiChatModel(Properties properties) {
+    AzureOpenAiChatModel openAiChatModel(Properties properties, ObjectProvider<ChatModelListener> listeners) {
         ChatModelProperties chatModelProperties = properties.chatModel();
         AzureOpenAiChatModel.Builder builder = AzureOpenAiChatModel.builder()
                 .endpoint(chatModelProperties.endpoint())
@@ -53,7 +57,8 @@ public class AutoConfig {
                 .logRequestsAndResponses(chatModelProperties.logRequestsAndResponses() != null && chatModelProperties.logRequestsAndResponses())
                 .userAgentSuffix(chatModelProperties.userAgentSuffix())
                 .customHeaders(chatModelProperties.customHeaders())
-                .supportedCapabilities(chatModelProperties.supportedCapabilities());
+                .supportedCapabilities(chatModelProperties.supportedCapabilities())
+                .listeners(listeners.orderedStream().toList());
         if (chatModelProperties.nonAzureApiKey() != null) {
             builder.nonAzureApiKey(chatModelProperties.nonAzureApiKey());
         }
@@ -62,17 +67,20 @@ public class AutoConfig {
 
     @Bean
     @ConditionalOnProperty(Properties.PREFIX + ".streaming-chat-model.api-key")
-    AzureOpenAiStreamingChatModel openAiStreamingChatModelByApiKey(Properties properties) {
-        return openAiStreamingChatModel(properties);
+    AzureOpenAiStreamingChatModel openAiStreamingChatModelByApiKey(Properties properties,
+                                                                   ObjectProvider<ChatModelListener> listeners) {
+        return openAiStreamingChatModel(properties, listeners);
     }
 
     @Bean
     @ConditionalOnProperty(Properties.PREFIX + ".streaming-chat-model.non-azure-api-key")
-    AzureOpenAiStreamingChatModel openAiStreamingChatModelByNonAzureApiKey(Properties properties) {
-        return openAiStreamingChatModel(properties);
+    AzureOpenAiStreamingChatModel openAiStreamingChatModelByNonAzureApiKey(Properties properties,
+                                                                           ObjectProvider<ChatModelListener> listeners) {
+        return openAiStreamingChatModel(properties, listeners);
     }
 
-    AzureOpenAiStreamingChatModel openAiStreamingChatModel(Properties properties) {
+    AzureOpenAiStreamingChatModel openAiStreamingChatModel(Properties properties,
+                                                           ObjectProvider<ChatModelListener> listeners) {
         ChatModelProperties chatModelProperties = properties.streamingChatModel();
         AzureOpenAiStreamingChatModel.Builder builder = AzureOpenAiStreamingChatModel.builder()
                 .endpoint(chatModelProperties.endpoint())
@@ -94,7 +102,8 @@ public class AutoConfig {
                 .proxyOptions(ProxyOptions.fromConfiguration(Configuration.getGlobalConfiguration()))
                 .logRequestsAndResponses(chatModelProperties.logRequestsAndResponses() != null && chatModelProperties.logRequestsAndResponses())
                 .userAgentSuffix(chatModelProperties.userAgentSuffix())
-                .customHeaders(chatModelProperties.customHeaders());
+                .customHeaders(chatModelProperties.customHeaders())
+                .listeners(listeners.orderedStream().toList());
         if (chatModelProperties.nonAzureApiKey() != null) {
             builder.nonAzureApiKey(chatModelProperties.nonAzureApiKey());
         }

--- a/langchain4j-azure-open-ai-spring-boot-starter/src/test/java/dev/langchain4j/azure/openai/spring/AutoConfigIT.java
+++ b/langchain4j-azure-open-ai-spring-boot-starter/src/test/java/dev/langchain4j/azure/openai/spring/AutoConfigIT.java
@@ -200,7 +200,7 @@ class AutoConfigIT {
 
                     ImageModel imageModel = context.getBean(ImageModel.class);
                     assertThat(imageModel).isInstanceOf(AzureOpenAiImageModel.class);
-                    assertThat(imageModel.generate("banana").content().url()).isNotNull();
+                    assertThat(imageModel.generate("coffee").content().url()).isNotNull();
 
                     assertThat(context.getBean(AzureOpenAiImageModel.class)).isSameAs(imageModel);
                 });

--- a/langchain4j-azure-open-ai-spring-boot-starter/src/test/java/dev/langchain4j/azure/openai/spring/AutoConfigIT.java
+++ b/langchain4j-azure-open-ai-spring-boot-starter/src/test/java/dev/langchain4j/azure/openai/spring/AutoConfigIT.java
@@ -8,6 +8,7 @@ import dev.langchain4j.model.azure.AzureOpenAiImageModel;
 import dev.langchain4j.model.azure.AzureOpenAiStreamingChatModel;
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.json.JsonArraySchema;
@@ -20,10 +21,14 @@ import dev.langchain4j.model.output.Response;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static dev.langchain4j.data.message.UserMessage.userMessage;
@@ -31,6 +36,8 @@ import static dev.langchain4j.model.chat.request.ResponseFormatType.JSON;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 
 class AutoConfigIT {
 
@@ -63,10 +70,32 @@ class AutoConfigIT {
                 });
     }
 
-    class Person {
+    @Test
+    void should_provide_chat_model_with_listeners() {
+        contextRunner
+                .withPropertyValues(
+                        "langchain4j.azure-open-ai.chat-model.api-key=" + AZURE_OPENAI_KEY,
+                        "langchain4j.azure-open-ai.chat-model.endpoint=" + AZURE_OPENAI_ENDPOINT,
+                        "langchain4j.azure-open-ai.chat-model.deployment-name=gpt-4o-mini",
+                        "langchain4j.azure-open-ai.chat-model.max-tokens=20"
+                )
+                .withUserConfiguration(ListenerConfig.class)
+                .run(context -> {
 
-        String name;
-        List<String> favouriteColors;
+                    ChatLanguageModel chatLanguageModel = context.getBean(ChatLanguageModel.class);
+                    assertThat(chatLanguageModel).isInstanceOf(AzureOpenAiChatModel.class);
+                    assertThat(chatLanguageModel.generate("What is the capital of Germany?")).contains("Berlin");
+                    assertThat(context.getBean(AzureOpenAiChatModel.class)).isSameAs(chatLanguageModel);
+
+                    ChatModelListener listener1 = context.getBean("listener1", ChatModelListener.class);
+                    ChatModelListener listener2 = context.getBean("listener2", ChatModelListener.class);
+                    InOrder inOrder = Mockito.inOrder(listener1, listener2);
+                    inOrder.verify(listener2).onRequest(any());
+                    inOrder.verify(listener1).onRequest(any());
+                    inOrder.verify(listener2).onResponse(any());
+                    inOrder.verify(listener1).onResponse(any());
+                    inOrder.verifyNoMoreInteractions();
+                });
     }
 
     @ParameterizedTest(name = "Deployment name: {0}")
@@ -173,6 +202,53 @@ class AutoConfigIT {
     }
 
     @Test
+    void should_provide_streaming_chat_model_with_listeners() {
+        contextRunner
+                .withPropertyValues(
+                        "langchain4j.azure-open-ai.streaming-chat-model.api-key=" + AZURE_OPENAI_KEY,
+                        "langchain4j.azure-open-ai.streaming-chat-model.endpoint=" + AZURE_OPENAI_ENDPOINT,
+                        "langchain4j.azure-open-ai.streaming-chat-model.deployment-name=gpt-4o-mini",
+                        "langchain4j.azure-open-ai.streaming-chat-model.max-tokens=20",
+                        "langchain4j.azure-open-ai.streaming-chat-model.timeout=60"
+                )
+                .withUserConfiguration(ListenerConfig.class)
+                .run(context -> {
+
+                    StreamingChatLanguageModel streamingChatLanguageModel = context.getBean(StreamingChatLanguageModel.class);
+                    assertThat(streamingChatLanguageModel).isInstanceOf(AzureOpenAiStreamingChatModel.class);
+                    CompletableFuture<Response<AiMessage>> future = new CompletableFuture<>();
+                    streamingChatLanguageModel.generate("What is the capital of Germany?", new StreamingResponseHandler<AiMessage>() {
+
+                        @Override
+                        public void onNext(String token) {
+                        }
+
+                        @Override
+                        public void onComplete(Response<AiMessage> response) {
+                            future.complete(response);
+                        }
+
+                        @Override
+                        public void onError(Throwable error) {
+                        }
+                    });
+                    Response<AiMessage> response = future.get(60, SECONDS);
+                    assertThat(response.content().text()).contains("Berlin");
+
+                    assertThat(context.getBean(AzureOpenAiStreamingChatModel.class)).isSameAs(streamingChatLanguageModel);
+
+                    ChatModelListener listener1 = context.getBean("listener1", ChatModelListener.class);
+                    ChatModelListener listener2 = context.getBean("listener2", ChatModelListener.class);
+                    InOrder inOrder = Mockito.inOrder(listener1, listener2);
+                    inOrder.verify(listener2).onRequest(any());
+                    inOrder.verify(listener1).onRequest(any());
+                    inOrder.verify(listener2).onResponse(any());
+                    inOrder.verify(listener1).onResponse(any());
+                    inOrder.verifyNoMoreInteractions();
+                });
+    }
+
+    @Test
     void should_provide_embedding_model() {
         contextRunner
                 .withPropertyValues("langchain4j.azure-open-ai.embedding-model.api-key=" + AZURE_OPENAI_KEY,
@@ -204,5 +280,21 @@ class AutoConfigIT {
 
                     assertThat(context.getBean(AzureOpenAiImageModel.class)).isSameAs(imageModel);
                 });
+    }
+
+    @Configuration
+    static class ListenerConfig {
+
+        @Bean
+        @Order(2)
+        ChatModelListener listener1() {
+            return mock(ChatModelListener.class);
+        }
+
+        @Bean
+        @Order(1)
+        ChatModelListener listener2() {
+            return mock(ChatModelListener.class);
+        }
     }
 }

--- a/langchain4j-github-models-spring-boot-starter/src/main/java/dev/langchain4j/model/githubmodels/spring/AutoConfig.java
+++ b/langchain4j-github-models-spring-boot-starter/src/main/java/dev/langchain4j/model/githubmodels/spring/AutoConfig.java
@@ -2,9 +2,11 @@ package dev.langchain4j.model.githubmodels.spring;
 
 import com.azure.core.http.ProxyOptions;
 import com.azure.core.util.Configuration;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.github.GitHubModelsChatModel;
 import dev.langchain4j.model.github.GitHubModelsEmbeddingModel;
 import dev.langchain4j.model.github.GitHubModelsStreamingChatModel;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -16,7 +18,7 @@ public class AutoConfig {
 
     @Bean
     @ConditionalOnProperty(Properties.PREFIX + ".chat-model.github-token")
-    GitHubModelsChatModel gitHubModelsChatModel(Properties properties) {
+    GitHubModelsChatModel gitHubModelsChatModel(Properties properties, ObjectProvider<ChatModelListener> listeners) {
         ChatModelProperties chatModelProperties = properties.getChatModel();
         GitHubModelsChatModel.Builder builder = GitHubModelsChatModel.builder()
                 .endpoint(chatModelProperties.getEndpoint())
@@ -30,14 +32,16 @@ public class AutoConfig {
                 .timeout(chatModelProperties.getTimeout())
                 .maxRetries(chatModelProperties.getMaxRetries())
                 .proxyOptions(ProxyOptions.fromConfiguration(Configuration.getGlobalConfiguration()))
-                .logRequestsAndResponses(chatModelProperties.getLogRequestsAndResponses() != null && chatModelProperties.getLogRequestsAndResponses());
+                .logRequestsAndResponses(chatModelProperties.getLogRequestsAndResponses() != null && chatModelProperties.getLogRequestsAndResponses())
+                .listeners(listeners.orderedStream().toList());
 
         return builder.build();
     }
 
     @Bean
     @ConditionalOnProperty(Properties.PREFIX + ".streaming-chat-model.github-token")
-    GitHubModelsStreamingChatModel gitHubModelsStreamingChatModel(Properties properties) {
+    GitHubModelsStreamingChatModel gitHubModelsStreamingChatModel(Properties properties,
+                                                                  ObjectProvider<ChatModelListener> listeners) {
         ChatModelProperties chatModelProperties = properties.getStreamingChatModel();
         GitHubModelsStreamingChatModel.Builder builder = GitHubModelsStreamingChatModel.builder()
                 .endpoint(chatModelProperties.getEndpoint())
@@ -51,7 +55,8 @@ public class AutoConfig {
                 .frequencyPenalty(chatModelProperties.getFrequencyPenalty())
                 .timeout(chatModelProperties.getTimeout())
                 .proxyOptions(ProxyOptions.fromConfiguration(Configuration.getGlobalConfiguration()))
-                .logRequestsAndResponses(chatModelProperties.getLogRequestsAndResponses() != null && chatModelProperties.getLogRequestsAndResponses());
+                .logRequestsAndResponses(chatModelProperties.getLogRequestsAndResponses() != null && chatModelProperties.getLogRequestsAndResponses())
+                .listeners(listeners.orderedStream().toList());
 
         return builder.build();
     }

--- a/langchain4j-ollama-spring-boot-starter/src/main/java/dev/langchain4j/ollama/spring/AutoConfig.java
+++ b/langchain4j-ollama-spring-boot-starter/src/main/java/dev/langchain4j/ollama/spring/AutoConfig.java
@@ -1,6 +1,8 @@
 package dev.langchain4j.ollama.spring;
 
+import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.ollama.*;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -14,7 +16,7 @@ public class AutoConfig {
 
     @Bean
     @ConditionalOnProperty(PREFIX + ".chat-model.base-url")
-    OllamaChatModel ollamaChatModel(Properties properties) {
+    OllamaChatModel ollamaChatModel(Properties properties, ObjectProvider<ChatModelListener> listeners) {
         ChatModelProperties chatModelProperties = properties.getChatModel();
         return OllamaChatModel.builder()
                 .baseUrl(chatModelProperties.getBaseUrl())
@@ -33,12 +35,14 @@ public class AutoConfig {
                 .customHeaders(chatModelProperties.getCustomHeaders())
                 .logRequests(chatModelProperties.getLogRequests())
                 .logResponses(chatModelProperties.getLogResponses())
+                .listeners(listeners.orderedStream().toList())
                 .build();
     }
 
     @Bean
     @ConditionalOnProperty(PREFIX + ".streaming-chat-model.base-url")
-    OllamaStreamingChatModel ollamaStreamingChatModel(Properties properties) {
+    OllamaStreamingChatModel ollamaStreamingChatModel(Properties properties,
+                                                      ObjectProvider<ChatModelListener> listeners) {
         ChatModelProperties chatModelProperties = properties.getStreamingChatModel();
         return OllamaStreamingChatModel.builder()
                 .baseUrl(chatModelProperties.getBaseUrl())
@@ -56,6 +60,7 @@ public class AutoConfig {
                 .customHeaders(chatModelProperties.getCustomHeaders())
                 .logRequests(chatModelProperties.getLogRequests())
                 .logResponses(chatModelProperties.getLogResponses())
+                .listeners(listeners.orderedStream().toList())
                 .build();
     }
 

--- a/langchain4j-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/openai/spring/AutoConfig.java
+++ b/langchain4j-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/openai/spring/AutoConfig.java
@@ -1,6 +1,8 @@
 package dev.langchain4j.openai.spring;
 
+import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.openai.*;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -15,7 +17,7 @@ public class AutoConfig {
 
     @Bean
     @ConditionalOnProperty(PREFIX + ".chat-model.api-key")
-    OpenAiChatModel openAiChatModel(Properties properties) {
+    OpenAiChatModel openAiChatModel(Properties properties, ObjectProvider<ChatModelListener> listeners) {
         ChatModelProperties chatModelProperties = properties.chatModel();
         return OpenAiChatModel.builder()
                 .baseUrl(chatModelProperties.baseUrl())
@@ -42,12 +44,14 @@ public class AutoConfig {
                 .logRequests(chatModelProperties.logRequests())
                 .logResponses(chatModelProperties.logResponses())
                 .customHeaders(chatModelProperties.customHeaders())
+                .listeners(listeners.orderedStream().toList())
                 .build();
     }
 
     @Bean
     @ConditionalOnProperty(PREFIX + ".streaming-chat-model.api-key")
-    OpenAiStreamingChatModel openAiStreamingChatModel(Properties properties) {
+    OpenAiStreamingChatModel openAiStreamingChatModel(Properties properties,
+                                                      ObjectProvider<ChatModelListener> listeners) {
         ChatModelProperties chatModelProperties = properties.streamingChatModel();
         return OpenAiStreamingChatModel.builder()
                 .baseUrl(chatModelProperties.baseUrl())
@@ -72,6 +76,7 @@ public class AutoConfig {
                 .logRequests(chatModelProperties.logRequests())
                 .logResponses(chatModelProperties.logResponses())
                 .customHeaders(chatModelProperties.customHeaders())
+                .listeners(listeners.orderedStream().toList())
                 .build();
     }
 

--- a/langchain4j-open-ai-spring-boot-starter/src/test/java/dev/langchain4j/openai/spring/AutoConfigIT.java
+++ b/langchain4j-open-ai-spring-boot-starter/src/test/java/dev/langchain4j/openai/spring/AutoConfigIT.java
@@ -4,6 +4,7 @@ import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.StreamingResponseHandler;
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.image.ImageModel;
 import dev.langchain4j.model.language.LanguageModel;
@@ -12,13 +13,20 @@ import dev.langchain4j.model.moderation.ModerationModel;
 import dev.langchain4j.model.openai.*;
 import dev.langchain4j.model.output.Response;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 
 import java.util.concurrent.CompletableFuture;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 
 class AutoConfigIT {
 
@@ -41,6 +49,33 @@ class AutoConfigIT {
                     assertThat(chatLanguageModel.generate("What is the capital of Germany?")).contains("Berlin");
 
                     assertThat(context.getBean(OpenAiChatModel.class)).isSameAs(chatLanguageModel);
+                });
+    }
+
+    @Test
+    void should_provide_chat_model_with_listeners() {
+        contextRunner
+                .withPropertyValues(
+                        "langchain4j.open-ai.chat-model.api-key=" + API_KEY,
+                        "langchain4j.open-ai.chat-model.max-tokens=20"
+                )
+                .withUserConfiguration(ListenerConfig.class)
+                .run(context -> {
+
+                    ChatLanguageModel chatLanguageModel = context.getBean(ChatLanguageModel.class);
+                    assertThat(chatLanguageModel).isInstanceOf(OpenAiChatModel.class);
+                    assertThat(chatLanguageModel.generate("What is the capital of Germany?")).contains("Berlin");
+
+                    assertThat(context.getBean(OpenAiChatModel.class)).isSameAs(chatLanguageModel);
+
+                    ChatModelListener listener1 = context.getBean("listener1", ChatModelListener.class);
+                    ChatModelListener listener2 = context.getBean("listener2", ChatModelListener.class);
+                    InOrder inOrder = Mockito.inOrder(listener1, listener2);
+                    inOrder.verify(listener2).onRequest(any());
+                    inOrder.verify(listener1).onRequest(any());
+                    inOrder.verify(listener2).onResponse(any());
+                    inOrder.verify(listener1).onResponse(any());
+                    inOrder.verifyNoMoreInteractions();
                 });
     }
 
@@ -75,6 +110,50 @@ class AutoConfigIT {
                     assertThat(response.content().text()).contains("Berlin");
 
                     assertThat(context.getBean(OpenAiStreamingChatModel.class)).isSameAs(streamingChatLanguageModel);
+                });
+    }
+
+    @Test
+    void should_provide_streaming_chat_model_with_listeners() {
+        contextRunner
+                .withPropertyValues(
+                        "langchain4j.open-ai.streaming-chat-model.api-key=" + API_KEY,
+                        "langchain4j.open-ai.streaming-chat-model.max-tokens=20"
+                )
+                .withUserConfiguration(ListenerConfig.class)
+                .run(context -> {
+
+                    StreamingChatLanguageModel streamingChatLanguageModel = context.getBean(StreamingChatLanguageModel.class);
+                    assertThat(streamingChatLanguageModel).isInstanceOf(OpenAiStreamingChatModel.class);
+                    CompletableFuture<Response<AiMessage>> future = new CompletableFuture<>();
+                    streamingChatLanguageModel.generate("What is the capital of Germany?", new StreamingResponseHandler<AiMessage>() {
+
+                        @Override
+                        public void onNext(String token) {
+                        }
+
+                        @Override
+                        public void onComplete(Response<AiMessage> response) {
+                            future.complete(response);
+                        }
+
+                        @Override
+                        public void onError(Throwable error) {
+                        }
+                    });
+                    Response<AiMessage> response = future.get(60, SECONDS);
+                    assertThat(response.content().text()).contains("Berlin");
+
+                    assertThat(context.getBean(OpenAiStreamingChatModel.class)).isSameAs(streamingChatLanguageModel);
+
+                    ChatModelListener listener1 = context.getBean("listener1", ChatModelListener.class);
+                    ChatModelListener listener2 = context.getBean("listener2", ChatModelListener.class);
+                    InOrder inOrder = Mockito.inOrder(listener1, listener2);
+                    inOrder.verify(listener2).onRequest(any());
+                    inOrder.verify(listener1).onRequest(any());
+                    inOrder.verify(listener2).onResponse(any());
+                    inOrder.verify(listener1).onResponse(any());
+                    inOrder.verifyNoMoreInteractions();
                 });
     }
 
@@ -173,5 +252,21 @@ class AutoConfigIT {
 
                     assertThat(context.getBean(OpenAiImageModel.class)).isSameAs(imageModel);
                 });
+    }
+
+    @Configuration
+    static class ListenerConfig {
+
+        @Bean
+        @Order(2)
+        ChatModelListener listener1() {
+            return mock(ChatModelListener.class);
+        }
+
+        @Bean
+        @Order(1)
+        ChatModelListener listener2() {
+            return mock(ChatModelListener.class);
+        }
     }
 }

--- a/langchain4j-vertex-ai-gemini-spring-boot-starter/src/main/java/dev/langchain4j/vertexai/spring/AutoConfig.java
+++ b/langchain4j-vertex-ai-gemini-spring-boot-starter/src/main/java/dev/langchain4j/vertexai/spring/AutoConfig.java
@@ -1,7 +1,9 @@
 package dev.langchain4j.vertexai.spring;
 
+import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.vertexai.VertexAiGeminiChatModel;
 import dev.langchain4j.model.vertexai.VertexAiGeminiStreamingChatModel;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -15,7 +17,8 @@ public class AutoConfig {
 
     @Bean
     @ConditionalOnProperty(name = PREFIX + ".chat-model.enabled", havingValue = "true")
-    VertexAiGeminiChatModel vertexAiGeminiChatModel(Properties properties) {
+    VertexAiGeminiChatModel vertexAiGeminiChatModel(Properties properties,
+                                                    ObjectProvider<ChatModelListener> listeners) {
         ChatModelProperties chatModelProperties = properties.getChatModel();
         return VertexAiGeminiChatModel.builder()
                 .project(chatModelProperties.getProject())
@@ -26,12 +29,14 @@ public class AutoConfig {
                 .topK(chatModelProperties.getTopK())
                 .topP(chatModelProperties.getTopP())
                 .maxRetries(chatModelProperties.getMaxRetries())
+                .listeners(listeners.orderedStream().toList())
                 .build();
     }
 
     @Bean
     @ConditionalOnProperty(name = PREFIX + ".streaming-chat-model.enabled", havingValue = "true")
-    VertexAiGeminiStreamingChatModel vertexAiGeminiStreamingChatModel(Properties properties) {
+    VertexAiGeminiStreamingChatModel vertexAiGeminiStreamingChatModel(Properties properties,
+                                                                      ObjectProvider<ChatModelListener> listeners) {
         ChatModelProperties streamingChatProperties = properties.getStreamingChatModel();
         return VertexAiGeminiStreamingChatModel.builder()
                 .project(streamingChatProperties.getProject())
@@ -41,6 +46,7 @@ public class AutoConfig {
                 .maxOutputTokens(streamingChatProperties.getMaxOutputTokens())
                 .topK(streamingChatProperties.getTopK())
                 .topP(streamingChatProperties.getTopP())
+                .listeners(listeners.orderedStream().toList())
                 .build();
     }
 


### PR DESCRIPTION
## Issue
Closes https://github.com/langchain4j/langchain4j/issues/2145

## Change

For all `ChatLanguageModel` and `StreamingChatLanguageModel` beans, all available `ChatModelListener` beans will be automatically wired/injected.

## Example

With the following configuration:

```properties
langchain4j.open-ai.chat-model.api-key=${OPENAI_API_KEY}
langchain4j.open-ai.chat-model.model-name=gpt-4o-mini
```
```java
    @Bean
    ChatModelListener chatModelListener() {
        return new ChatModelListener() { ... };
    }
```
In this case `chatModelListener` bean will be automatically injected into `OpenAiChatModel` (configured in the `application.properties`).

---

If multiple listeners are required and ordering matters, order can be specified using Spring's `@Order` annotation:
```java
    @Bean
    @Order(1)
    ChatModelListener chatModelListener1() {
        return new ChatModelListener() { ... };
    }

    @Bean
    @Order(2)
    ChatModelListener chatModelListener2() {
        return new ChatModelListener() { ... };
    }
```

## General checklist
- [ ] There are no breaking changes
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs): https://github.com/langchain4j/langchain4j/commit/af1683e6eb312ff9fc8b188cba02f4730200143b
- [X] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples): https://github.com/langchain4j/langchain4j-examples/pull/139
