### PR TITLE
Bump Spring Boot baseline from 3.2 to 3.3

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
   java_build:
     strategy:
       matrix:
-        java_version: [ 17, 21, 22 ]
+        java_version: [ 17, 21, 22, 23 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -3,4 +3,4 @@
 # See https://sdkman.io/usage#config
 # A summary is to add the following to ~/.sdkman/etc/config
 # sdkman_auto_env=true
-java=17.0.11-tem
+java=17.0.14-tem

--- a/langchain4j-anthropic-spring-boot-starter/pom.xml
+++ b/langchain4j-anthropic-spring-boot-starter/pom.xml
@@ -19,7 +19,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-anthropic</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/langchain4j-anthropic-spring-boot-starter/src/test/java/dev/langchain4j/anthropic/spring/AutoConfigIT.java
+++ b/langchain4j-anthropic-spring-boot-starter/src/test/java/dev/langchain4j/anthropic/spring/AutoConfigIT.java
@@ -9,6 +9,7 @@ import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 import dev.langchain4j.model.output.Response;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
@@ -17,6 +18,7 @@ import java.util.concurrent.CompletableFuture;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+")
 class AutoConfigIT {
 
     private static final String API_KEY = System.getenv("ANTHROPIC_API_KEY");

--- a/langchain4j-azure-ai-search-spring-boot-starter/pom.xml
+++ b/langchain4j-azure-ai-search-spring-boot-starter/pom.xml
@@ -20,7 +20,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-azure-ai-search</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -57,7 +56,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId>
-            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/langchain4j-azure-ai-search-spring-boot-starter/src/test/java/dev/langchain4j/azure/aisearch/spring/AutoConfigIT.java
+++ b/langchain4j-azure-ai-search-spring-boot-starter/src/test/java/dev/langchain4j/azure/aisearch/spring/AutoConfigIT.java
@@ -30,6 +30,7 @@ import java.util.List;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@EnabledIfEnvironmentVariable(named = "AZURE_SEARCH_KEY", matches = ".+")
 class AutoConfigIT {
 
     private static final Logger log = LoggerFactory.getLogger(AutoConfigIT.class);

--- a/langchain4j-azure-open-ai-spring-boot-starter/pom.xml
+++ b/langchain4j-azure-open-ai-spring-boot-starter/pom.xml
@@ -20,7 +20,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-azure-open-ai</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/langchain4j-azure-open-ai-spring-boot-starter/src/test/java/dev/langchain4j/azure/openai/spring/AutoConfigIT.java
+++ b/langchain4j-azure-open-ai-spring-boot-starter/src/test/java/dev/langchain4j/azure/openai/spring/AutoConfigIT.java
@@ -19,6 +19,7 @@ import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.image.ImageModel;
 import dev.langchain4j.model.output.Response;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InOrder;
@@ -53,6 +54,7 @@ class AutoConfigIT {
             "gpt-4o-mini",
             "gpt-4o"
     })
+    @EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_KEY", matches = ".+")
     void should_provide_chat_model(String deploymentName) {
         contextRunner
                 .withPropertyValues(
@@ -71,6 +73,7 @@ class AutoConfigIT {
     }
 
     @Test
+    @EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_KEY", matches = ".+")
     void should_provide_chat_model_with_listeners() {
         contextRunner
                 .withPropertyValues(
@@ -102,6 +105,7 @@ class AutoConfigIT {
     @CsvSource({
             "gpt-4o-mini"
     })
+    @EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_KEY", matches = ".+")
     void should_provide_chat_model_with_json_schema(String deploymentName) {
         contextRunner
                 .withPropertyValues(
@@ -142,6 +146,7 @@ class AutoConfigIT {
     @CsvSource({
             "gpt-3.5-turbo"
     })
+    @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
     void should_provide_chat_model_no_azure(String deploymentName) {
         contextRunner
                 .withPropertyValues(
@@ -165,6 +170,7 @@ class AutoConfigIT {
             "gpt-4o-mini",
             "gpt-4o"
     })
+    @EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_KEY", matches = ".+")
     void should_provide_streaming_chat_model(String deploymentName) {
         contextRunner
                 .withPropertyValues(
@@ -202,6 +208,7 @@ class AutoConfigIT {
     }
 
     @Test
+    @EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_KEY", matches = ".+")
     void should_provide_streaming_chat_model_with_listeners() {
         contextRunner
                 .withPropertyValues(
@@ -249,6 +256,7 @@ class AutoConfigIT {
     }
 
     @Test
+    @EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_KEY", matches = ".+")
     void should_provide_embedding_model() {
         contextRunner
                 .withPropertyValues("langchain4j.azure-open-ai.embedding-model.api-key=" + AZURE_OPENAI_KEY,
@@ -265,6 +273,7 @@ class AutoConfigIT {
     }
 
     @Test
+    @EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_KEY", matches = ".+")
     void should_provide_image_model() {
         contextRunner
                 .withPropertyValues(

--- a/langchain4j-easy-rag-spring-boot-starter/pom.xml
+++ b/langchain4j-easy-rag-spring-boot-starter/pom.xml
@@ -19,7 +19,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-easy-rag</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/langchain4j-elasticsearch-spring-boot-starter/pom.xml
+++ b/langchain4j-elasticsearch-spring-boot-starter/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.17.0</version>
+            <version>2.18.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/langchain4j-github-models-spring-boot-starter/pom.xml
+++ b/langchain4j-github-models-spring-boot-starter/pom.xml
@@ -20,7 +20,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-github-models</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/langchain4j-github-models-spring-boot-starter/src/test/java/dev/langchain4j/model/githubmodels/spring/AutoConfigIT.java
+++ b/langchain4j-github-models-spring-boot-starter/src/test/java/dev/langchain4j/model/githubmodels/spring/AutoConfigIT.java
@@ -10,6 +10,7 @@ import dev.langchain4j.model.github.GitHubModelsEmbeddingModel;
 import dev.langchain4j.model.github.GitHubModelsStreamingChatModel;
 import dev.langchain4j.model.output.Response;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
@@ -18,6 +19,7 @@ import java.util.concurrent.CompletableFuture;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@EnabledIfEnvironmentVariable(named = "GITHUB_TOKEN", matches = ".+")
 class AutoConfigIT {
 
     private static final String GITHUB_TOKEN = System.getenv("GITHUB_TOKEN");

--- a/langchain4j-google-ai-gemini-spring-boot-starter/pom.xml
+++ b/langchain4j-google-ai-gemini-spring-boot-starter/pom.xml
@@ -20,7 +20,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-google-ai-gemini</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -46,8 +45,6 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-
-
 
     </dependencies>
 

--- a/langchain4j-google-ai-gemini-spring-boot-starter/src/test/java/dev/langchain4j/googleaigemini/spring/AutoConfigIT.java
+++ b/langchain4j-google-ai-gemini-spring-boot-starter/src/test/java/dev/langchain4j/googleaigemini/spring/AutoConfigIT.java
@@ -11,6 +11,7 @@ import dev.langchain4j.model.googleai.GoogleAiGeminiChatModel;
 import dev.langchain4j.model.googleai.GoogleAiGeminiStreamingChatModel;
 import dev.langchain4j.model.output.Response;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
@@ -19,6 +20,7 @@ import java.util.concurrent.CompletableFuture;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@EnabledIfEnvironmentVariable(named = "GOOGLE_AI_GEMINI_API_KEY", matches = ".+")
 class AutoConfigIT {
 
     private static final String API_KEY = System.getenv("GOOGLE_AI_GEMINI_API_KEY");

--- a/langchain4j-http-client-spring-restclient/pom.xml
+++ b/langchain4j-http-client-spring-restclient/pom.xml
@@ -19,7 +19,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-http-client</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -46,20 +45,19 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.4.1</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.projectreactor.netty</groupId>
             <artifactId>reactor-netty</artifactId>
-            <version>1.2.2</version>
             <scope>test</scope>
         </dependency>
 
+        <!-- Why "wiremock-jetty12" and not "wiremock": https://github.com/wiremock/wiremock/issues/2922 -->
         <dependency>
             <groupId>org.wiremock</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-jetty12</artifactId>
             <version>3.10.0</version>
             <scope>test</scope>
         </dependency>

--- a/langchain4j-ollama-spring-boot-starter/pom.xml
+++ b/langchain4j-ollama-spring-boot-starter/pom.xml
@@ -23,7 +23,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-ollama</artifactId>
-            <version>${project.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>dev.langchain4j</groupId>

--- a/langchain4j-ollama-spring-boot-starter/src/test/java/dev/langchain4j/ollama/spring/AutoConfigIT.java
+++ b/langchain4j-ollama-spring-boot-starter/src/test/java/dev/langchain4j/ollama/spring/AutoConfigIT.java
@@ -137,7 +137,7 @@ class AutoConfigIT {
         contextRunner.run(context -> {
 
             OllamaChatModel model = OllamaChatModel.builder()
-                    .baseUrl(OLLAMA_BASE_URL)
+                    .baseUrl(baseUrl())
                     .modelName(MODEL_NAME)
                     .temperature(0.0)
                     .numPredict(20)
@@ -273,7 +273,7 @@ class AutoConfigIT {
         contextRunner.run(context -> {
 
             OllamaStreamingChatModel model = OllamaStreamingChatModel.builder()
-                    .baseUrl(OLLAMA_BASE_URL)
+                    .baseUrl(baseUrl())
                     .modelName(MODEL_NAME)
                     .temperature(0.0)
                     .numPredict(20)
@@ -377,7 +377,7 @@ class AutoConfigIT {
         contextRunner.run(context -> {
 
             OllamaEmbeddingModel model = OllamaEmbeddingModel.builder()
-                    .baseUrl(OLLAMA_BASE_URL)
+                    .baseUrl(baseUrl())
                     .modelName(MODEL_NAME)
                     .build();
 

--- a/langchain4j-open-ai-spring-boot-starter/pom.xml
+++ b/langchain4j-open-ai-spring-boot-starter/pom.xml
@@ -19,7 +19,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-open-ai</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/langchain4j-open-ai-spring-boot-starter/src/test/java/dev/langchain4j/openai/spring/AutoConfigIT.java
+++ b/langchain4j-open-ai-spring-boot-starter/src/test/java/dev/langchain4j/openai/spring/AutoConfigIT.java
@@ -13,6 +13,7 @@ import dev.langchain4j.model.moderation.ModerationModel;
 import dev.langchain4j.model.openai.*;
 import dev.langchain4j.model.output.Response;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -28,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
 class AutoConfigIT {
 
     private static final String API_KEY = System.getenv("OPENAI_API_KEY");

--- a/langchain4j-reactor/pom.xml
+++ b/langchain4j-reactor/pom.xml
@@ -19,13 +19,11 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
-            <version>3.6.11</version>
         </dependency>
 
         <!-- TEST -->
@@ -33,28 +31,24 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
-            <version>3.7.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.11.3</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.26.3</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-open-ai</artifactId>
-            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/langchain4j-spring-boot-starter/pom.xml
+++ b/langchain4j-spring-boot-starter/pom.xml
@@ -19,7 +19,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -56,7 +55,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
-            <version>${spring.boot.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/langchain4j-vertex-ai-gemini-spring-boot-starter/pom.xml
+++ b/langchain4j-vertex-ai-gemini-spring-boot-starter/pom.xml
@@ -19,7 +19,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-vertex-ai-gemini</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/langchain4j-voyage-ai-spring-boot-starter/pom.xml
+++ b/langchain4j-voyage-ai-spring-boot-starter/pom.xml
@@ -23,7 +23,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-voyage-ai</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/langchain4j-voyage-ai-spring-boot-starter/src/test/java/dev/langchain4j/voyageai/spring/AutoConfigIT.java
+++ b/langchain4j-voyage-ai-spring-boot-starter/src/test/java/dev/langchain4j/voyageai/spring/AutoConfigIT.java
@@ -9,6 +9,7 @@ import dev.langchain4j.model.voyageai.VoyageAiEmbeddingModelName;
 import dev.langchain4j.model.voyageai.VoyageAiScoringModel;
 import dev.langchain4j.model.voyageai.VoyageAiScoringModelName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
@@ -17,6 +18,7 @@ import java.util.List;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@EnabledIfEnvironmentVariable(named = "VOYAGE_API_KEY", matches = ".+")
 class AutoConfigIT {
 
     ApplicationContextRunner contextRunner = new ApplicationContextRunner()

--- a/pom.xml
+++ b/pom.xml
@@ -37,10 +37,8 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tinylog.version>2.6.2</tinylog.version>
-        <spring.boot.version>3.2.6</spring.boot.version>
-        <spring.web.version>6.1.8</spring.web.version>
-        <testcontainers.version>1.20.3</testcontainers.version>
+        <spring.boot.version>3.3.8</spring.boot.version>
+        <testcontainers.version>1.20.4</testcontainers.version>
         <tinylog.version>2.7.0</tinylog.version>
     </properties>
 
@@ -55,72 +53,22 @@
                 <scope>import</scope>
             </dependency>
 
+            <!-- BOM for Spring Boot dependencies, including Framework, Reactor, Testcontainers, and Test -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot</artifactId>
+                <artifactId>spring-boot-dependencies</artifactId>
                 <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter</artifactId>
-                <version>${spring.boot.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-webflux</artifactId>
-                <version>${spring.boot.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-autoconfigure-processor</artifactId>
-                <version>${spring.boot.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-configuration-processor</artifactId>
-                <version>${spring.boot.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-test</artifactId>
-                <version>${spring.boot.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-web</artifactId>
-                <version>${spring.web.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok</artifactId>
-                <version>1.18.34</version>
-            </dependency>
-
+            <!-- BOM for Testcontainers dependencies, overriding the version from the Spring Boot BOM -->
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers-bom</artifactId>
                 <version>${testcontainers.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
-            </dependency>
-
-            <dependency>
-                <groupId>org.tinylog</groupId>
-                <artifactId>tinylog-impl</artifactId>
-                <version>${tinylog.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.tinylog</groupId>
-                <artifactId>slf4j-tinylog</artifactId>
-                <version>${tinylog.version}</version>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
## Change

- Update Spring Boot baseline to 3.3.8 because 3.2.x reached EOL (2024-11-23). See: https://spring.io/projects/spring-boot#support
- Use Spring Boot Dependencies BOM in parent pom.xml and simplified dependency management and versioning.
- Configured main pipeline to run tests on Java 23 as well.
- Fix Voyage autotests when API key is not configured.

## General checklist
- [X] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)