### PR TITLE
Removed usages of the old generate() API

### DIFF
--- a/langchain4j-anthropic-spring-boot-starter/src/test/java/dev/langchain4j/anthropic/spring/AutoConfigIT.java
+++ b/langchain4j-anthropic-spring-boot-starter/src/test/java/dev/langchain4j/anthropic/spring/AutoConfigIT.java
@@ -1,12 +1,11 @@
 package dev.langchain4j.anthropic.spring;
 
-import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.model.StreamingResponseHandler;
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
 import dev.langchain4j.model.anthropic.AnthropicStreamingChatModel;
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
-import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -42,7 +41,7 @@ class AutoConfigIT {
 
                     ChatLanguageModel chatLanguageModel = context.getBean(ChatLanguageModel.class);
                     assertThat(chatLanguageModel).isInstanceOf(AnthropicChatModel.class);
-                    assertThat(chatLanguageModel.generate("What is the capital of Germany?")).contains("Berlin");
+                    assertThat(chatLanguageModel.chat("What is the capital of Germany?")).contains("Berlin");
 
                     assertThat(context.getBean(AnthropicChatModel.class)).isSameAs(chatLanguageModel);
                 });
@@ -59,24 +58,24 @@ class AutoConfigIT {
 
                     StreamingChatLanguageModel streamingChatLanguageModel = context.getBean(StreamingChatLanguageModel.class);
                     assertThat(streamingChatLanguageModel).isInstanceOf(AnthropicStreamingChatModel.class);
-                    CompletableFuture<Response<AiMessage>> future = new CompletableFuture<>();
-                    streamingChatLanguageModel.generate("What is the capital of Germany?", new StreamingResponseHandler<AiMessage>() {
+                    CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+                    streamingChatLanguageModel.chat("What is the capital of Germany?", new StreamingChatResponseHandler() {
 
                         @Override
-                        public void onNext(String token) {
+                        public void onPartialResponse(String partialResponse) {
                         }
 
                         @Override
-                        public void onComplete(Response<AiMessage> response) {
-                            future.complete(response);
+                        public void onCompleteResponse(ChatResponse completeResponse) {
+                            future.complete(completeResponse);
                         }
 
                         @Override
                         public void onError(Throwable error) {
                         }
                     });
-                    Response<AiMessage> response = future.get(60, SECONDS);
-                    assertThat(response.content().text()).contains("Berlin");
+                    ChatResponse response = future.get(60, SECONDS);
+                    assertThat(response.aiMessage().text()).contains("Berlin");
 
                     assertThat(context.getBean(AnthropicStreamingChatModel.class)).isSameAs(streamingChatLanguageModel);
                 });

--- a/langchain4j-azure-open-ai-spring-boot-starter/src/test/java/dev/langchain4j/azure/openai/spring/AutoConfigIT.java
+++ b/langchain4j-azure-open-ai-spring-boot-starter/src/test/java/dev/langchain4j/azure/openai/spring/AutoConfigIT.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.azure.openai.spring;
 
 import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.model.StreamingResponseHandler;
 import dev.langchain4j.model.azure.AzureOpenAiChatModel;
 import dev.langchain4j.model.azure.AzureOpenAiEmbeddingModel;
 import dev.langchain4j.model.azure.AzureOpenAiImageModel;
@@ -15,9 +14,10 @@ import dev.langchain4j.model.chat.request.json.JsonArraySchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.model.chat.request.json.JsonStringSchema;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.image.ImageModel;
-import dev.langchain4j.model.output.Response;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -67,7 +67,7 @@ class AutoConfigIT {
 
                     ChatLanguageModel chatLanguageModel = context.getBean(ChatLanguageModel.class);
                     assertThat(chatLanguageModel).isInstanceOf(AzureOpenAiChatModel.class);
-                    assertThat(chatLanguageModel.generate("What is the capital of Germany?")).contains("Berlin");
+                    assertThat(chatLanguageModel.chat("What is the capital of Germany?")).contains("Berlin");
                     assertThat(context.getBean(AzureOpenAiChatModel.class)).isSameAs(chatLanguageModel);
                 });
     }
@@ -87,7 +87,7 @@ class AutoConfigIT {
 
                     ChatLanguageModel chatLanguageModel = context.getBean(ChatLanguageModel.class);
                     assertThat(chatLanguageModel).isInstanceOf(AzureOpenAiChatModel.class);
-                    assertThat(chatLanguageModel.generate("What is the capital of Germany?")).contains("Berlin");
+                    assertThat(chatLanguageModel.chat("What is the capital of Germany?")).contains("Berlin");
                     assertThat(context.getBean(AzureOpenAiChatModel.class)).isSameAs(chatLanguageModel);
 
                     ChatModelListener listener1 = context.getBean("listener1", ChatModelListener.class);
@@ -159,7 +159,7 @@ class AutoConfigIT {
 
                     ChatLanguageModel chatLanguageModel = context.getBean(ChatLanguageModel.class);
                     assertThat(chatLanguageModel).isInstanceOf(AzureOpenAiChatModel.class);
-                    assertThat(chatLanguageModel.generate("What is the capital of Germany?")).contains("Berlin");
+                    assertThat(chatLanguageModel.chat("What is the capital of Germany?")).contains("Berlin");
 
                     assertThat(context.getBean(AzureOpenAiChatModel.class)).isSameAs(chatLanguageModel);
                 });
@@ -184,24 +184,24 @@ class AutoConfigIT {
 
                     StreamingChatLanguageModel streamingChatLanguageModel = context.getBean(StreamingChatLanguageModel.class);
                     assertThat(streamingChatLanguageModel).isInstanceOf(AzureOpenAiStreamingChatModel.class);
-                    CompletableFuture<Response<AiMessage>> future = new CompletableFuture<>();
-                    streamingChatLanguageModel.generate("What is the capital of Germany?", new StreamingResponseHandler<AiMessage>() {
+                    CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+                    streamingChatLanguageModel.chat("What is the capital of Germany?", new StreamingChatResponseHandler() {
 
                         @Override
-                        public void onNext(String token) {
+                        public void onPartialResponse(String partialResponse) {
                         }
 
                         @Override
-                        public void onComplete(Response<AiMessage> response) {
-                            future.complete(response);
+                        public void onCompleteResponse(ChatResponse completeResponse) {
+                            future.complete(completeResponse);
                         }
 
                         @Override
                         public void onError(Throwable error) {
                         }
                     });
-                    Response<AiMessage> response = future.get(60, SECONDS);
-                    assertThat(response.content().text()).contains("Berlin");
+                    ChatResponse response = future.get(60, SECONDS);
+                    assertThat(response.aiMessage().text()).contains("Berlin");
 
                     assertThat(context.getBean(AzureOpenAiStreamingChatModel.class)).isSameAs(streamingChatLanguageModel);
                 });
@@ -223,24 +223,24 @@ class AutoConfigIT {
 
                     StreamingChatLanguageModel streamingChatLanguageModel = context.getBean(StreamingChatLanguageModel.class);
                     assertThat(streamingChatLanguageModel).isInstanceOf(AzureOpenAiStreamingChatModel.class);
-                    CompletableFuture<Response<AiMessage>> future = new CompletableFuture<>();
-                    streamingChatLanguageModel.generate("What is the capital of Germany?", new StreamingResponseHandler<AiMessage>() {
+                    CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+                    streamingChatLanguageModel.chat("What is the capital of Germany?", new StreamingChatResponseHandler() {
 
                         @Override
-                        public void onNext(String token) {
+                        public void onPartialResponse(String partialResponse) {
                         }
 
                         @Override
-                        public void onComplete(Response<AiMessage> response) {
-                            future.complete(response);
+                        public void onCompleteResponse(ChatResponse completeResponse) {
+                            future.complete(completeResponse);
                         }
 
                         @Override
                         public void onError(Throwable error) {
                         }
                     });
-                    Response<AiMessage> response = future.get(60, SECONDS);
-                    assertThat(response.content().text()).contains("Berlin");
+                    ChatResponse response = future.get(60, SECONDS);
+                    assertThat(response.aiMessage().text()).contains("Berlin");
 
                     assertThat(context.getBean(AzureOpenAiStreamingChatModel.class)).isSameAs(streamingChatLanguageModel);
 

--- a/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/conflictingSyncAndStreamingModels/streaming/AiServiceWithConflictingSyncAndStreamingModelsApplication.java
+++ b/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/conflictingSyncAndStreamingModels/streaming/AiServiceWithConflictingSyncAndStreamingModelsApplication.java
@@ -1,6 +1,8 @@
 package dev.langchain4j.service.spring.mode.automatic.conflictingSyncAndStreamingModels.streaming;
 
 import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
@@ -10,8 +12,12 @@ class AiServiceWithConflictingSyncAndStreamingModelsApplication {
 
     @Bean
     ChatLanguageModel chatLanguageModel() {
-        return (messages) -> {
-            throw new RuntimeException("should never be invoked");
+        return new ChatLanguageModel() {
+
+            @Override
+            public ChatResponse chat(ChatRequest chatRequest) {
+                throw new RuntimeException("should never be invoked");
+            }
         };
     }
 

--- a/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/conflictingSyncAndStreamingModels/sync/AiServiceWithConflictingSyncAndStreamingModelsApplication.java
+++ b/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/conflictingSyncAndStreamingModels/sync/AiServiceWithConflictingSyncAndStreamingModelsApplication.java
@@ -1,6 +1,8 @@
 package dev.langchain4j.service.spring.mode.automatic.conflictingSyncAndStreamingModels.sync;
 
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
@@ -10,8 +12,12 @@ class AiServiceWithConflictingSyncAndStreamingModelsApplication {
 
     @Bean
     StreamingChatLanguageModel streamingChatLanguageModel() {
-        return (messages, handler) -> {
-            throw new RuntimeException("should never be invoked");
+        return new StreamingChatLanguageModel() {
+
+            @Override
+            public void chat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+                throw new RuntimeException("should never be invoked");
+            }
         };
     }
 

--- a/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/explicit/chatModel/AiServiceWithExplicitChatModelApplication.java
+++ b/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/explicit/chatModel/AiServiceWithExplicitChatModelApplication.java
@@ -1,6 +1,8 @@
 package dev.langchain4j.service.spring.mode.explicit.chatModel;
 
 import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -23,8 +25,12 @@ class AiServiceWithExplicitChatModelApplication {
 
     @Bean(CHAT_MODEL_BEAN_NAME + 2)
     ChatLanguageModel chatLanguageModel2() {
-        return messages -> {
-            throw new RuntimeException("should never be invoked");
+        return new ChatLanguageModel() {
+
+            @Override
+            public ChatResponse chat(ChatRequest chatRequest) {
+                throw new RuntimeException("should never be invoked");
+            }
         };
     }
 

--- a/langchain4j-vertex-ai-gemini-spring-boot-starter/src/test/java/dev/langchain4j/vertexai/spring/AutoConfigIT.java
+++ b/langchain4j-vertex-ai-gemini-spring-boot-starter/src/test/java/dev/langchain4j/vertexai/spring/AutoConfigIT.java
@@ -1,10 +1,9 @@
 package dev.langchain4j.vertexai.spring;
 
-import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.model.StreamingResponseHandler;
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
-import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.vertexai.VertexAiGeminiChatModel;
 import dev.langchain4j.model.vertexai.VertexAiGeminiStreamingChatModel;
 import org.junit.jupiter.api.Test;
@@ -43,7 +42,7 @@ class AutoConfigIT {
                     assertThat(chatLanguageModel).isInstanceOf(VertexAiGeminiChatModel.class);
 
                     // when
-                    String message = chatLanguageModel.generate("What is the capital of Germany?");
+                    String message = chatLanguageModel.chat("What is the capital of Germany?");
 
                     // then
                     assertThat(message).contains("Berlin");
@@ -65,27 +64,27 @@ class AutoConfigIT {
 
                     StreamingChatLanguageModel streamingChatLanguageModel = context.getBean(StreamingChatLanguageModel.class);
                     assertThat(streamingChatLanguageModel).isInstanceOf(VertexAiGeminiStreamingChatModel.class);
-                    CompletableFuture<Response<AiMessage>> future = new CompletableFuture<>();
+                    CompletableFuture<ChatResponse> future = new CompletableFuture<>();
                     // when
-                    streamingChatLanguageModel.generate("What is the capital of Germany?", new StreamingResponseHandler<>() {
+                    streamingChatLanguageModel.chat("What is the capital of Germany?", new StreamingChatResponseHandler() {
 
                         @Override
-                        public void onNext(String token) {
+                        public void onPartialResponse(String partialResponse) {
                         }
 
                         @Override
-                        public void onComplete(Response<AiMessage> response) {
-                            future.complete(response);
+                        public void onCompleteResponse(ChatResponse completeResponse) {
+                            future.complete(completeResponse);
                         }
 
                         @Override
                         public void onError(Throwable error) {
                         }
                     });
-                    Response<AiMessage> response = future.get(60, SECONDS);
+                    ChatResponse response = future.get(60, SECONDS);
 
                     // then
-                    assertThat(response.content().text()).contains("Berlin");
+                    assertThat(response.aiMessage().text()).contains("Berlin");
                     assertThat(context.getBean(VertexAiGeminiStreamingChatModel.class)).isSameAs(streamingChatLanguageModel);
                 });
     }


### PR DESCRIPTION
## Change
Removed usages of the old generate() API

## General checklist
- [X] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)