### PR TITLE
Remove deprecated EmbeddingStore.findRelevant API

### DIFF
--- a/langchain4j-azure-ai-search-spring-boot-starter/src/test/java/dev/langchain4j/azure/aisearch/spring/AutoConfigIT.java
+++ b/langchain4j-azure-ai-search-spring-boot-starter/src/test/java/dev/langchain4j/azure/aisearch/spring/AutoConfigIT.java
@@ -15,6 +15,7 @@ import dev.langchain4j.rag.content.retriever.azure.search.AzureAiSearchContentRe
 import dev.langchain4j.rag.content.retriever.azure.search.AzureAiSearchQueryType;
 import dev.langchain4j.rag.query.Query;
 import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.azure.search.AzureAiSearchEmbeddingStore;
 import org.junit.jupiter.api.AfterEach;
@@ -237,8 +238,12 @@ class AutoConfigIT {
                         embeddingStore.add(embedding, textSegment);
                     }
 
-                    Embedding relevantEmbedding = embeddingModel.embed("fruit").content();
-                    List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(relevantEmbedding, 3);
+                    EmbeddingSearchRequest searchRequest = EmbeddingSearchRequest.builder()
+                            .queryEmbedding(embeddingModel.embed("fruit").content())
+                            .maxResults(3)
+                            .build();
+
+                    List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.search(searchRequest).matches();
                     assertThat(relevant).hasSize(3);
                     // TODO uncomment after https://github.com/langchain4j/langchain4j/issues/1617 is closed
                     // assertThat(relevant.get(0).embedding()).isNotNull();

--- a/langchain4j-spring-boot-tests/src/test/java/dev/langchain4j/store/embedding/spring/EmbeddingStoreAutoConfigurationIT.java
+++ b/langchain4j-spring-boot-tests/src/test/java/dev/langchain4j/store/embedding/spring/EmbeddingStoreAutoConfigurationIT.java
@@ -61,7 +61,11 @@ public abstract class EmbeddingStoreAutoConfigurationIT {
 
                     awaitUntilPersisted(context);
 
-                    List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
+                    EmbeddingSearchRequest searchRequest = EmbeddingSearchRequest.builder()
+                            .queryEmbedding(embedding)
+                            .maxResults(10)
+                            .build();
+                    List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.search(searchRequest).matches();
                     assertThat(relevant).hasSize(1);
 
                     EmbeddingMatch<TextSegment> match = relevant.get(0);
@@ -90,23 +94,15 @@ public abstract class EmbeddingStoreAutoConfigurationIT {
 
                     awaitUntilPersisted(context);
 
-                    List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-                    assertThat(relevant).hasSize(1);
-
-                    EmbeddingMatch<TextSegment> match = relevant.get(0);
-                    assertThat(match.score()).isCloseTo(1, withPercentage(1));
-                    assertThat(match.embeddingId()).isEqualTo(id);
-                    assertThat(match.embedding()).isEqualTo(embedding);
-                    assertThat(match.embedded()).isEqualTo(segment);
-
-                    // New API
-                    EmbeddingSearchResult<TextSegment> searchResult = embeddingStore.search(EmbeddingSearchRequest.builder()
+                    EmbeddingSearchRequest searchRequest = EmbeddingSearchRequest.builder()
                             .queryEmbedding(embedding)
                             .maxResults(10)
-                            .build());
+                            .build();
 
-                    assertThat(searchResult.matches()).hasSize(1);
-                    match = searchResult.matches().get(0);
+                    List<EmbeddingMatch<TextSegment>> matches = embeddingStore.search(searchRequest).matches();
+                    assertThat(matches).hasSize(1);
+
+                    EmbeddingMatch<TextSegment> match = matches.get(0);
                     assertThat(match.score()).isCloseTo(1, withPercentage(1));
                     assertThat(match.embeddingId()).isEqualTo(id);
                     assertThat(match.embedding()).isEqualTo(embedding);


### PR DESCRIPTION
## Change
This is a part of https://github.com/langchain4j/langchain4j/pull/2750

## General checklist
- [ ] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features