### PR TITLE
OpenAI: remove deprecated APIs

### DIFF
--- a/langchain4j-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/openai/spring/AutoConfig.java
+++ b/langchain4j-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/openai/spring/AutoConfig.java
@@ -363,10 +363,4 @@ public class AutoConfig {
                 // executor is not needed for no-streaming OpenAiImageModel
                 .createDefaultStreamingRequestExecutor(false);
     }
-
-    @Bean
-    @ConditionalOnMissingBean
-    OpenAiTokenizer openAiTokenizer() {
-        return new OpenAiTokenizer();
-    }
 }


### PR DESCRIPTION
## Breaking Change

`OpenAiTokenizer` bean is no longer created automatically as there is no default constructor any more and there is no way to configure the model for the tokenizer.

This is a part of https://github.com/langchain4j/langchain4j/pull/2792


## General checklist
- [ ] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)