### PR TITLE
Issues3073: support ToolProvider automatically wired into the AI Service if available in the application contex

### DIFF
--- a/langchain4j-spring-boot-starter/src/main/java/dev/langchain4j/service/spring/AiService.java
+++ b/langchain4j-spring-boot-starter/src/main/java/dev/langchain4j/service/spring/AiService.java
@@ -9,6 +9,7 @@ import dev.langchain4j.model.moderation.ModerationModel;
 import dev.langchain4j.rag.RetrievalAugmentor;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.tool.ToolProvider;
 import org.springframework.stereotype.Service;
 
 import java.lang.annotation.Retention;
@@ -103,4 +104,10 @@ public @interface AiService {
      * this attribute specifies the names of beans containing methods annotated with {@link Tool} that should be used by this AI Service.
      */
     String[] tools() default {};
+
+    /**
+     * When the {@link #wiringMode()} is set to {@link AiServiceWiringMode#EXPLICIT},
+     * this attribute specifies the name of a {@link ToolProvider} bean that should be used by this AI Service.
+     */
+    String toolProvider() default "";
 }

--- a/langchain4j-spring-boot-starter/src/main/java/dev/langchain4j/service/spring/AiServiceFactory.java
+++ b/langchain4j-spring-boot-starter/src/main/java/dev/langchain4j/service/spring/AiServiceFactory.java
@@ -12,6 +12,7 @@ import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.service.AiServices;
 import dev.langchain4j.service.tool.DefaultToolExecutor;
 import dev.langchain4j.service.tool.ToolExecutor;
+import dev.langchain4j.service.tool.ToolProvider;
 import org.springframework.beans.factory.FactoryBean;
 
 import java.lang.reflect.Method;
@@ -36,6 +37,7 @@ class AiServiceFactory implements FactoryBean<Object> {
     private RetrievalAugmentor retrievalAugmentor;
     private ModerationModel moderationModel;
     private List<Object> tools;
+    private ToolProvider toolProvider;
 
     public AiServiceFactory(Class<Object> aiServiceClass) {
         this.aiServiceClass = aiServiceClass;
@@ -71,6 +73,10 @@ class AiServiceFactory implements FactoryBean<Object> {
 
     public void setTools(List<Object> tools) {
         this.tools = tools;
+    }
+
+    public void setToolProvider(ToolProvider toolProvider) {
+        this.toolProvider = toolProvider;
     }
 
     @Override
@@ -112,6 +118,9 @@ class AiServiceFactory implements FactoryBean<Object> {
                     builder = builder.tools(tool);
                 }
             }
+        }
+        if (toolProvider != null) {
+            builder = builder.toolProvider(toolProvider);
         }
 
         return builder.build();

--- a/langchain4j-spring-boot-starter/src/main/java/dev/langchain4j/service/spring/AiServicesAutoConfig.java
+++ b/langchain4j-spring-boot-starter/src/main/java/dev/langchain4j/service/spring/AiServicesAutoConfig.java
@@ -12,6 +12,7 @@ import dev.langchain4j.rag.RetrievalAugmentor;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.service.IllegalConfigurationException;
 import dev.langchain4j.service.spring.event.AiServiceRegisteredEvent;
+import dev.langchain4j.service.tool.ToolProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.MutablePropertyValues;
@@ -58,6 +59,7 @@ public class AiServicesAutoConfig implements ApplicationEventPublisherAware {
             String[] contentRetrievers = beanFactory.getBeanNamesForType(ContentRetriever.class);
             String[] retrievalAugmentors = beanFactory.getBeanNamesForType(RetrievalAugmentor.class);
             String[] moderationModels = beanFactory.getBeanNamesForType(ModerationModel.class);
+            String[] toolProviders = beanFactory.getBeanNamesForType(ToolProvider.class);
 
             Set<String> toolBeanNames = new HashSet<>();
             List<ToolSpecification> toolSpecifications = new ArrayList<>();
@@ -162,6 +164,16 @@ public class AiServicesAutoConfig implements ApplicationEventPublisherAware {
                         moderationModels,
                         "moderationModel",
                         "moderationModel",
+                        propertyValues
+                );
+
+                addBeanReference(
+                        ToolProvider.class,
+                        aiServiceAnnotation,
+                        aiServiceAnnotation.toolProvider(),
+                        toolProviders,
+                        "toolProvider",
+                        "toolProvider",
                         propertyValues
                 );
 

--- a/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/issue3074/AiServiceWithToolProvider.java
+++ b/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/issue3074/AiServiceWithToolProvider.java
@@ -1,0 +1,8 @@
+package dev.langchain4j.service.spring.mode.automatic.issue3074;
+
+import dev.langchain4j.service.spring.AiService;
+
+@AiService
+public interface AiServiceWithToolProvider {
+    String chat(String userMessage);
+}

--- a/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/issue3074/TestAutowireAiServiceToolProviderApplication.java
+++ b/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/issue3074/TestAutowireAiServiceToolProviderApplication.java
@@ -1,0 +1,19 @@
+package dev.langchain4j.service.spring.mode.automatic.issue3074;
+
+import dev.langchain4j.service.tool.ToolProvider;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+
+@SpringBootApplication
+public class TestAutowireAiServiceToolProviderApplication {
+    @Bean
+    public ToolProvider toolProvider() {
+        return new TestMcpToolProvider();
+    }
+
+    public static void main(String[] args) {
+        SpringApplication.run(TestAutowireAiServiceToolProviderApplication.class, args);
+    }
+}

--- a/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/issue3074/TestAutowireAiServiceToolProviderApplication.java
+++ b/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/issue3074/TestAutowireAiServiceToolProviderApplication.java
@@ -1,13 +1,26 @@
 package dev.langchain4j.service.spring.mode.automatic.issue3074;
 
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.service.tool.ToolProvider;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
+import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O_MINI;
+
 
 @SpringBootApplication
 public class TestAutowireAiServiceToolProviderApplication {
+
+    @Bean
+    ChatModel chatModel() {
+        return OpenAiChatModel.builder()
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .modelName(GPT_4_O_MINI)
+                .build();
+    }
+
     @Bean
     public ToolProvider toolProvider() {
         return new TestMcpToolProvider();

--- a/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/issue3074/TestAutowrieToolProvider.java
+++ b/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/issue3074/TestAutowrieToolProvider.java
@@ -1,0 +1,22 @@
+package dev.langchain4j.service.spring.mode.automatic.issue3074;
+
+import dev.langchain4j.service.spring.AiServicesAutoConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+public class TestAutowrieToolProvider {
+
+    ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(AiServicesAutoConfig.class));
+
+    @Test
+    void should_fail_to_create_AI_service_when_conflicting_chat_models_are_found() {
+        contextRunner
+                .withUserConfiguration(TestAutowireAiServiceToolProviderApplication.class)
+                .run(context -> {
+                    Assertions.assertDoesNotThrow(() -> context.getBean(TestMcpToolProvider.class));
+                });
+    }
+}

--- a/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/issue3074/TestAutowrieToolProvider.java
+++ b/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/issue3074/TestAutowrieToolProvider.java
@@ -1,10 +1,20 @@
 package dev.langchain4j.service.spring.mode.automatic.issue3074;
 
+import dev.langchain4j.service.AiServiceContext;
+import dev.langchain4j.service.AiServices;
 import dev.langchain4j.service.spring.AiServicesAutoConfig;
+import dev.langchain4j.service.tool.ToolProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.springframework.aop.framework.Advised;
+import org.springframework.aop.support.AopUtils;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 
 public class TestAutowrieToolProvider {
 
@@ -16,7 +26,33 @@ public class TestAutowrieToolProvider {
         contextRunner
                 .withUserConfiguration(TestAutowireAiServiceToolProviderApplication.class)
                 .run(context -> {
-                    Assertions.assertDoesNotThrow(() -> context.getBean(TestMcpToolProvider.class));
+                    ToolProvider toolProviderBean = context.getBean(ToolProvider.class);
+                    Assertions.assertNotNull(toolProviderBean, "ToolProvider bean should be present in the context.");
+
+                    AiServiceWithToolProvider aiServiceProxy = context.getBean(AiServiceWithToolProvider.class);
+                    Assertions.assertNotNull(aiServiceProxy, "AiServiceWithToolProvider should be created successfully.");
+
+                    InvocationHandler handler = Proxy.getInvocationHandler(aiServiceProxy);
+                    Assertions.assertNotNull(handler, "InvocationHandler should be present.");
+                    Field this$0 = handler.getClass().getDeclaredField("this$0");
+                    this$0.setAccessible(true);
+                    Object aiServices = this$0.get(handler);
+
+                    Field contextField = aiServices.getClass().getSuperclass().getDeclaredField("context");
+                    contextField.setAccessible(true);
+                    AiServiceContext aiServiceContext = (AiServiceContext) contextField.get(aiServices);
+                    Assertions.assertNotNull(aiServiceContext, "AiServiceContext should be present.");
+
+                    Field aiServiceField = aiServiceContext.getClass().getDeclaredField("toolService");
+                    aiServiceField.setAccessible(true);
+                    Object toolService = aiServiceField.get(aiServiceContext);
+
+                    Field toolProvider = toolService.getClass().getDeclaredField("toolProvider");
+                    toolProvider.setAccessible(true);
+                    Object toolProviderObj = toolProvider.get(toolService);
+                    Assertions.assertInstanceOf(TestMcpToolProvider.class, toolProviderObj, "ToolProvider should be TestMcpToolProvider.");
+
+
                 });
     }
 }

--- a/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/issue3074/TestMcpToolProvider.java
+++ b/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/mode/automatic/issue3074/TestMcpToolProvider.java
@@ -1,0 +1,12 @@
+package dev.langchain4j.service.spring.mode.automatic.issue3074;
+
+import dev.langchain4j.service.tool.ToolProvider;
+import dev.langchain4j.service.tool.ToolProviderRequest;
+import dev.langchain4j.service.tool.ToolProviderResult;
+
+public class TestMcpToolProvider implements ToolProvider {
+    @Override
+    public ToolProviderResult provideTools(ToolProviderRequest toolProviderRequest) {
+        return null;
+    }
+}


### PR DESCRIPTION
## Issue
Closes [#3073](https://github.com/langchain4j/langchain4j/issues/3073)

## Change
support ToolProvider automatically wired into the AI Service if available in the application contex

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
