### PR TITLE
Azure OpenAI: prepare for 1.0

### DIFF
--- a/langchain4j-azure-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/azure/openai/spring/AutoConfig.java
+++ b/langchain4j-azure-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/azure/openai/spring/AutoConfig.java
@@ -6,7 +6,6 @@ import dev.langchain4j.model.azure.*;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -53,9 +52,9 @@ public class AutoConfig {
                 .proxyOptions(ProxyOptions.fromConfiguration(Configuration.getGlobalConfiguration()))
                 .logRequestsAndResponses(chatModelProperties.logRequestsAndResponses() != null && chatModelProperties.logRequestsAndResponses())
                 .userAgentSuffix(chatModelProperties.userAgentSuffix())
+                .listeners(listeners.orderedStream().toList())
                 .customHeaders(chatModelProperties.customHeaders())
-                .supportedCapabilities(chatModelProperties.supportedCapabilities())
-                .listeners(listeners.orderedStream().toList());
+                .supportedCapabilities(chatModelProperties.supportedCapabilities());
         if (chatModelProperties.nonAzureApiKey() != null) {
             builder.nonAzureApiKey(chatModelProperties.nonAzureApiKey());
         }
@@ -98,8 +97,9 @@ public class AutoConfig {
                 .proxyOptions(ProxyOptions.fromConfiguration(Configuration.getGlobalConfiguration()))
                 .logRequestsAndResponses(chatModelProperties.logRequestsAndResponses() != null && chatModelProperties.logRequestsAndResponses())
                 .userAgentSuffix(chatModelProperties.userAgentSuffix())
+                .listeners(listeners.orderedStream().toList())
                 .customHeaders(chatModelProperties.customHeaders())
-                .listeners(listeners.orderedStream().toList());
+                .supportedCapabilities(chatModelProperties.supportedCapabilities());
         if (chatModelProperties.nonAzureApiKey() != null) {
             builder.nonAzureApiKey(chatModelProperties.nonAzureApiKey());
         }
@@ -172,11 +172,5 @@ public class AutoConfig {
             builder.nonAzureApiKey(imageModelProperties.nonAzureApiKey());
         }
         return builder.build();
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    AzureOpenAiTokenCountEstimator azureOpenAiTokenCountEstimator() {
-        return new AzureOpenAiTokenCountEstimator();
     }
 }


### PR DESCRIPTION
## Issue
This is a part of https://github.com/langchain4j/langchain4j/pull/3155

## Change
Removed `AzureOpenAiTokenCountEstimator` bean auto-configured by default. Please configure it yourself and explicitly specify the model name.

## General checklist
- [ ] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)