### PR TITLE
test: Use Elasticsearch 8.19.2 image to support Apple M4

### DIFF
--- a/langchain4j-elasticsearch-spring-boot-starter/pom.xml
+++ b/langchain4j-elasticsearch-spring-boot-starter/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <!-- For tests only -->
-        <elastic.version>8.14.3</elastic.version>
+        <elastic.version>8.19.2</elastic.version>
         <!-- You can run the tests using
         # Elasticsearch Cloud
         mvn verify -DELASTICSEARCH_URL=https://URL.elastic-cloud.com -DELASTICSEARCH_API_KEY=THE_KEY


### PR DESCRIPTION
## Change
The Testcontainers image used for Elasticsearch is not compatible with Apple Silicon M4, so the tests always fail there. I updated the image to version 8.19.2. This is just for testing and doesn't have any impact on production code.


## General checklist
- [x] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)


## Checklist for adding new Spring Boot starter
- [ ] I have added my new starter in the root `pom.xml`
- [ ] I have added a `org.springframework.boot.autoconfigure.AutoConfiguration.imports` file in the `langchain4j-{integration}-spring-boot-starter/src/main/resources/META-INF/spring/` directory
