### PR TITLE
build: Fix duplicate tinylog dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,14 +74,7 @@
             <dependency>
                 <groupId>org.tinylog</groupId>
                 <artifactId>tinylog-impl</artifactId>
-                <version>2.6.2</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.tinylog</groupId>
-                <artifactId>slf4j-tinylog</artifactId>
-                <version>2.6.2</version>
+                <version>${tinylog.version}</version>
                 <scope>test</scope>
             </dependency>
 
@@ -89,12 +82,7 @@
                 <groupId>org.tinylog</groupId>
                 <artifactId>slf4j-tinylog</artifactId>
                 <version>${tinylog.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.tinylog</groupId>
-                <artifactId>tinylog-impl</artifactId>
-                <version>${tinylog.version}</version>
+                <scope>test</scope>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
## Change
The slf4j-tinylog and tinylog-impl dependencies were duplicated and also with different versions. There's now only a single pair with the latest version and correctly included in the test classpath only.


## General checklist
- [X] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)


## Checklist for adding new Spring Boot starter
- [ ] I have added my new starter in the root `pom.xml`
- [ ] I have added a `org.springframework.boot.autoconfigure.AutoConfiguration.imports` file in the `langchain4j-{integration}-spring-boot-starter/src/main/resources/META-INF/spring/` directory
