### PR TITLE
test: Make it possible to run OpenAI tests locally

### DIFF
--- a/langchain4j-open-ai-spring-boot-starter/src/test/java/dev/langchain4j/openai/spring/AutoConfigIT.java
+++ b/langchain4j-open-ai-spring-boot-starter/src/test/java/dev/langchain4j/openai/spring/AutoConfigIT.java
@@ -23,6 +23,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 import java.util.concurrent.CompletableFuture;
@@ -36,7 +37,8 @@ import static org.mockito.Mockito.*;
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
 class AutoConfigIT {
 
-    private static final String BASE_URL = System.getenv("OPENAI_BASE_URL");
+    private static final String BASE_URL = StringUtils.hasText(System.getenv("OPENAI_BASE_URL"))
+            ? System.getenv("OPENAI_BASE_URL") : "https://api.openai.com/v1";
     private static final String API_KEY = System.getenv("OPENAI_API_KEY");
 
     ApplicationContextRunner contextRunner = new ApplicationContextRunner()


### PR DESCRIPTION
## Change
The OpenAI tests required to pass an OPENAI_BASE_URL environment variable that is only available in the CI pipeline. This change adds a default, fallback value in case that's not defined, making it possible to run the tests locally easily.


## General checklist
- [X] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)


## Checklist for adding new Spring Boot starter
- [ ] I have added my new starter in the root `pom.xml`
- [ ] I have added a `org.springframework.boot.autoconfigure.AutoConfiguration.imports` file in the `langchain4j-{integration}-spring-boot-starter/src/main/resources/META-INF/spring/` directory
