### PR TITLE
Add Spring Boot starters for OpenAI Official (langchain4j-open-ai-official)

### DIFF
--- a/langchain4j-open-ai-official-spring-boot-starter/pom.xml
+++ b/langchain4j-open-ai-official-spring-boot-starter/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-spring</artifactId>
+        <version>1.14.0-beta24-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-open-ai-official-spring-boot-starter</artifactId>
+    <name>LangChain4j Spring Boot starter for OpenAI Official</name>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-open-ai-official</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- needed to generate automatic metadata about available config properties -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/langchain4j-open-ai-official-spring-boot-starter/src/main/java/dev/langchain4j/openaiofficial/spring/AutoConfig.java
+++ b/langchain4j-open-ai-official-spring-boot-starter/src/main/java/dev/langchain4j/openaiofficial/spring/AutoConfig.java
@@ -1,0 +1,141 @@
+package dev.langchain4j.openaiofficial.spring;
+
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialChatModel;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialChatRequestParameters;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialEmbeddingModel;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialImageModel;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialStreamingChatModel;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+import static dev.langchain4j.openaiofficial.spring.Properties.PREFIX;
+
+@AutoConfiguration
+@EnableConfigurationProperties(Properties.class)
+public class AutoConfig {
+
+    @Bean
+    @ConditionalOnProperty(PREFIX + ".chat-model.api-key")
+    @ConditionalOnMissingBean
+    OpenAiOfficialChatModel openAiOfficialChatModel(Properties properties,
+                                                     ObjectProvider<ChatModelListener> listeners) {
+        ChatModelProperties chatModelProperties = properties.chatModel();
+        return OpenAiOfficialChatModel.builder()
+                .baseUrl(chatModelProperties.baseUrl())
+                .apiKey(chatModelProperties.apiKey())
+                .organizationId(chatModelProperties.organizationId())
+                .isMicrosoftFoundry(Boolean.TRUE.equals(chatModelProperties.isMicrosoftFoundry()))
+                .microsoftFoundryDeploymentName(chatModelProperties.microsoftFoundryDeploymentName())
+                .modelName(chatModelProperties.modelName())
+                .temperature(chatModelProperties.temperature())
+                .topP(chatModelProperties.topP())
+                .stop(chatModelProperties.stop())
+                .maxCompletionTokens(chatModelProperties.maxCompletionTokens())
+                .presencePenalty(chatModelProperties.presencePenalty())
+                .frequencyPenalty(chatModelProperties.frequencyPenalty())
+                .logitBias(chatModelProperties.logitBias())
+                .responseFormat(chatModelProperties.responseFormat())
+                .strictJsonSchema(chatModelProperties.strictJsonSchema())
+                .seed(chatModelProperties.seed())
+                .user(chatModelProperties.user())
+                .strictTools(chatModelProperties.strictTools())
+                .parallelToolCalls(chatModelProperties.parallelToolCalls())
+                .store(chatModelProperties.store())
+                .metadata(chatModelProperties.metadata())
+                .serviceTier(chatModelProperties.serviceTier())
+                .supportedCapabilities(chatModelProperties.supportedCapabilities())
+                .defaultRequestParameters(OpenAiOfficialChatRequestParameters.builder()
+                        .reasoningEffort(chatModelProperties.reasoningEffort())
+                        .build())
+                .timeout(chatModelProperties.timeout())
+                .maxRetries(chatModelProperties.maxRetries())
+                .customHeaders(chatModelProperties.customHeaders())
+                .listeners(listeners.orderedStream().toList())
+                .build();
+    }
+
+    @Bean
+    @ConditionalOnProperty(PREFIX + ".streaming-chat-model.api-key")
+    @ConditionalOnMissingBean
+    OpenAiOfficialStreamingChatModel openAiOfficialStreamingChatModel(Properties properties,
+                                                                      ObjectProvider<ChatModelListener> listeners) {
+        ChatModelProperties chatModelProperties = properties.streamingChatModel();
+        return OpenAiOfficialStreamingChatModel.builder()
+                .baseUrl(chatModelProperties.baseUrl())
+                .apiKey(chatModelProperties.apiKey())
+                .organizationId(chatModelProperties.organizationId())
+                .isMicrosoftFoundry(Boolean.TRUE.equals(chatModelProperties.isMicrosoftFoundry()))
+                .microsoftFoundryDeploymentName(chatModelProperties.microsoftFoundryDeploymentName())
+                .modelName(chatModelProperties.modelName())
+                .temperature(chatModelProperties.temperature())
+                .topP(chatModelProperties.topP())
+                .stop(chatModelProperties.stop())
+                .maxCompletionTokens(chatModelProperties.maxCompletionTokens())
+                .presencePenalty(chatModelProperties.presencePenalty())
+                .frequencyPenalty(chatModelProperties.frequencyPenalty())
+                .logitBias(chatModelProperties.logitBias())
+                .responseFormat(chatModelProperties.responseFormat())
+                .strictJsonSchema(chatModelProperties.strictJsonSchema())
+                .seed(chatModelProperties.seed())
+                .user(chatModelProperties.user())
+                .strictTools(chatModelProperties.strictTools())
+                .parallelToolCalls(chatModelProperties.parallelToolCalls())
+                .store(chatModelProperties.store())
+                .metadata(chatModelProperties.metadata())
+                .serviceTier(chatModelProperties.serviceTier())
+                .supportedCapabilities(chatModelProperties.supportedCapabilities())
+                .defaultRequestParameters(OpenAiOfficialChatRequestParameters.builder()
+                        .reasoningEffort(chatModelProperties.reasoningEffort())
+                        .build())
+                .timeout(chatModelProperties.timeout())
+                .maxRetries(chatModelProperties.maxRetries())
+                .customHeaders(chatModelProperties.customHeaders())
+                .listeners(listeners.orderedStream().toList())
+                .build();
+    }
+
+    @Bean
+    @ConditionalOnProperty(PREFIX + ".embedding-model.api-key")
+    @ConditionalOnMissingBean
+    OpenAiOfficialEmbeddingModel openAiOfficialEmbeddingModel(Properties properties) {
+        EmbeddingModelProperties embeddingModelProperties = properties.embeddingModel();
+        return OpenAiOfficialEmbeddingModel.builder()
+                .baseUrl(embeddingModelProperties.baseUrl())
+                .apiKey(embeddingModelProperties.apiKey())
+                .organizationId(embeddingModelProperties.organizationId())
+                .modelName(embeddingModelProperties.modelName())
+                .dimensions(embeddingModelProperties.dimensions())
+                .user(embeddingModelProperties.user())
+                .maxSegmentsPerBatch(embeddingModelProperties.maxSegmentsPerBatch())
+                .timeout(embeddingModelProperties.timeout())
+                .maxRetries(embeddingModelProperties.maxRetries())
+                .customHeaders(embeddingModelProperties.customHeaders())
+                .build();
+    }
+
+    @Bean
+    @ConditionalOnProperty(PREFIX + ".image-model.api-key")
+    @ConditionalOnMissingBean
+    OpenAiOfficialImageModel openAiOfficialImageModel(Properties properties) {
+        ImageModelProperties imageModelProperties = properties.imageModel();
+        return OpenAiOfficialImageModel.builder()
+                .baseUrl(imageModelProperties.baseUrl())
+                .apiKey(imageModelProperties.apiKey())
+                .organizationId(imageModelProperties.organizationId())
+                .modelName(imageModelProperties.modelName())
+                .size(imageModelProperties.size())
+                .quality(imageModelProperties.quality())
+                .style(imageModelProperties.style())
+                .user(imageModelProperties.user())
+                .responseFormat(imageModelProperties.responseFormat())
+                .timeout(imageModelProperties.timeout())
+                .maxRetries(imageModelProperties.maxRetries())
+                .customHeaders(imageModelProperties.customHeaders())
+                .build();
+    }
+}

--- a/langchain4j-open-ai-official-spring-boot-starter/src/main/java/dev/langchain4j/openaiofficial/spring/ChatModelProperties.java
+++ b/langchain4j-open-ai-official-spring-boot-starter/src/main/java/dev/langchain4j/openaiofficial/spring/ChatModelProperties.java
@@ -1,0 +1,39 @@
+package dev.langchain4j.openaiofficial.spring;
+
+import dev.langchain4j.model.chat.Capability;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+record ChatModelProperties(
+        String baseUrl,
+        String apiKey,
+        String organizationId,
+        Boolean isMicrosoftFoundry,
+        String microsoftFoundryDeploymentName,
+        String modelName,
+        Double temperature,
+        Double topP,
+        List<String> stop,
+        Integer maxCompletionTokens,
+        Double presencePenalty,
+        Double frequencyPenalty,
+        Map<String, Integer> logitBias,
+        String responseFormat,
+        Boolean strictJsonSchema,
+        Integer seed,
+        String user,
+        Boolean strictTools,
+        Boolean parallelToolCalls,
+        Boolean store,
+        Map<String, String> metadata,
+        String serviceTier,
+        String reasoningEffort,
+        Set<Capability> supportedCapabilities,
+        Duration timeout,
+        Integer maxRetries,
+        Map<String, String> customHeaders
+) {
+}

--- a/langchain4j-open-ai-official-spring-boot-starter/src/main/java/dev/langchain4j/openaiofficial/spring/EmbeddingModelProperties.java
+++ b/langchain4j-open-ai-official-spring-boot-starter/src/main/java/dev/langchain4j/openaiofficial/spring/EmbeddingModelProperties.java
@@ -1,0 +1,18 @@
+package dev.langchain4j.openaiofficial.spring;
+
+import java.time.Duration;
+import java.util.Map;
+
+record EmbeddingModelProperties(
+        String baseUrl,
+        String apiKey,
+        String organizationId,
+        String modelName,
+        Integer dimensions,
+        String user,
+        Integer maxSegmentsPerBatch,
+        Duration timeout,
+        Integer maxRetries,
+        Map<String, String> customHeaders
+) {
+}

--- a/langchain4j-open-ai-official-spring-boot-starter/src/main/java/dev/langchain4j/openaiofficial/spring/ImageModelProperties.java
+++ b/langchain4j-open-ai-official-spring-boot-starter/src/main/java/dev/langchain4j/openaiofficial/spring/ImageModelProperties.java
@@ -1,0 +1,20 @@
+package dev.langchain4j.openaiofficial.spring;
+
+import java.time.Duration;
+import java.util.Map;
+
+record ImageModelProperties(
+        String baseUrl,
+        String apiKey,
+        String organizationId,
+        String modelName,
+        String size,
+        String quality,
+        String style,
+        String user,
+        String responseFormat,
+        Duration timeout,
+        Integer maxRetries,
+        Map<String, String> customHeaders
+) {
+}

--- a/langchain4j-open-ai-official-spring-boot-starter/src/main/java/dev/langchain4j/openaiofficial/spring/Properties.java
+++ b/langchain4j-open-ai-official-spring-boot-starter/src/main/java/dev/langchain4j/openaiofficial/spring/Properties.java
@@ -1,0 +1,23 @@
+package dev.langchain4j.openaiofficial.spring;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+@ConfigurationProperties(prefix = Properties.PREFIX)
+public record Properties(
+
+    @NestedConfigurationProperty
+    ChatModelProperties chatModel,
+
+    @NestedConfigurationProperty
+    ChatModelProperties streamingChatModel,
+
+    @NestedConfigurationProperty
+    EmbeddingModelProperties embeddingModel,
+
+    @NestedConfigurationProperty
+    ImageModelProperties imageModel
+) {
+    static final String PREFIX = "langchain4j.open-ai-official";
+
+}

--- a/langchain4j-open-ai-official-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/langchain4j-open-ai-official-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.langchain4j.openaiofficial.spring.AutoConfig

--- a/langchain4j-open-ai-official-spring-boot-starter/src/test/java/dev/langchain4j/openaiofficial/spring/AutoConfigIT.java
+++ b/langchain4j-open-ai-official-spring-boot-starter/src/test/java/dev/langchain4j/openaiofficial/spring/AutoConfigIT.java
@@ -39,14 +39,15 @@ class AutoConfigIT {
     class OpenAi {
 
         private static final String API_KEY = System.getenv("OPENAI_API_KEY");
+        private static final String MODEL_NAME = "gpt-5-mini";
 
         @Test
         void should_provide_chat_model() {
             contextRunner
                     .withPropertyValues(
                             "langchain4j.open-ai-official.chat-model.api-key=" + API_KEY,
-                            "langchain4j.open-ai-official.chat-model.model-name=gpt-4o-mini",
-                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=20"
+                            "langchain4j.open-ai-official.chat-model.model-name=" + MODEL_NAME,
+                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=200"
                     )
                     .run(context -> {
 
@@ -63,8 +64,8 @@ class AutoConfigIT {
             contextRunner
                     .withPropertyValues(
                             "langchain4j.open-ai-official.chat-model.api-key=" + API_KEY,
-                            "langchain4j.open-ai-official.chat-model.model-name=gpt-4o-mini",
-                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=20"
+                            "langchain4j.open-ai-official.chat-model.model-name=" + MODEL_NAME,
+                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=200"
                     )
                     .withUserConfiguration(ListenerConfig.class)
                     .run(context -> {
@@ -90,8 +91,8 @@ class AutoConfigIT {
             contextRunner
                     .withPropertyValues(
                             "langchain4j.open-ai-official.streaming-chat-model.api-key=" + API_KEY,
-                            "langchain4j.open-ai-official.streaming-chat-model.model-name=gpt-4o-mini",
-                            "langchain4j.open-ai-official.streaming-chat-model.max-completion-tokens=20"
+                            "langchain4j.open-ai-official.streaming-chat-model.model-name=" + MODEL_NAME,
+                            "langchain4j.open-ai-official.streaming-chat-model.max-completion-tokens=200"
                     )
                     .run(context -> {
 
@@ -123,23 +124,21 @@ class AutoConfigIT {
     }
 
     @Nested
-    @EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_API_KEY", matches = ".+")
-    class AzureOpenAi {
+    @EnabledIfEnvironmentVariable(named = "MICROSOFT_FOUNDRY_API_KEY", matches = ".+")
+    class MicrosoftFoundry {
 
-        private static final String AZURE_ENDPOINT = System.getenv("AZURE_OPENAI_ENDPOINT");
-        private static final String API_KEY = System.getenv("AZURE_OPENAI_API_KEY");
-        private static final String DEPLOYMENT_NAME = System.getenv("AZURE_OPENAI_DEPLOYMENT_NAME");
+        private static final String ENDPOINT = System.getenv("MICROSOFT_FOUNDRY_ENDPOINT");
+        private static final String API_KEY = System.getenv("MICROSOFT_FOUNDRY_API_KEY");
+        private static final String MODEL_NAME = "gpt-5-mini";
 
         @Test
         void should_provide_chat_model() {
             contextRunner
                     .withPropertyValues(
-                            "langchain4j.open-ai-official.chat-model.base-url=" + AZURE_ENDPOINT,
+                            "langchain4j.open-ai-official.chat-model.base-url=" + ENDPOINT,
                             "langchain4j.open-ai-official.chat-model.api-key=" + API_KEY,
-                            "langchain4j.open-ai-official.chat-model.is-microsoft-foundry=true",
-                            "langchain4j.open-ai-official.chat-model.microsoft-foundry-deployment-name=" + DEPLOYMENT_NAME,
-                            "langchain4j.open-ai-official.chat-model.model-name=" + DEPLOYMENT_NAME,
-                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=20"
+                            "langchain4j.open-ai-official.chat-model.model-name=" + MODEL_NAME,
+                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=200"
                     )
                     .run(context -> {
 
@@ -155,12 +154,10 @@ class AutoConfigIT {
         void should_provide_chat_model_with_listeners() {
             contextRunner
                     .withPropertyValues(
-                            "langchain4j.open-ai-official.chat-model.base-url=" + AZURE_ENDPOINT,
+                            "langchain4j.open-ai-official.chat-model.base-url=" + ENDPOINT,
                             "langchain4j.open-ai-official.chat-model.api-key=" + API_KEY,
-                            "langchain4j.open-ai-official.chat-model.is-microsoft-foundry=true",
-                            "langchain4j.open-ai-official.chat-model.microsoft-foundry-deployment-name=" + DEPLOYMENT_NAME,
-                            "langchain4j.open-ai-official.chat-model.model-name=" + DEPLOYMENT_NAME,
-                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=20"
+                            "langchain4j.open-ai-official.chat-model.model-name=" + MODEL_NAME,
+                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=200"
                     )
                     .withUserConfiguration(ListenerConfig.class)
                     .run(context -> {
@@ -185,12 +182,10 @@ class AutoConfigIT {
         void should_provide_streaming_chat_model() {
             contextRunner
                     .withPropertyValues(
-                            "langchain4j.open-ai-official.streaming-chat-model.base-url=" + AZURE_ENDPOINT,
+                            "langchain4j.open-ai-official.streaming-chat-model.base-url=" + ENDPOINT,
                             "langchain4j.open-ai-official.streaming-chat-model.api-key=" + API_KEY,
-                            "langchain4j.open-ai-official.streaming-chat-model.is-microsoft-foundry=true",
-                            "langchain4j.open-ai-official.streaming-chat-model.microsoft-foundry-deployment-name=" + DEPLOYMENT_NAME,
-                            "langchain4j.open-ai-official.streaming-chat-model.model-name=" + DEPLOYMENT_NAME,
-                            "langchain4j.open-ai-official.streaming-chat-model.max-completion-tokens=20"
+                            "langchain4j.open-ai-official.streaming-chat-model.model-name=" + MODEL_NAME,
+                            "langchain4j.open-ai-official.streaming-chat-model.max-completion-tokens=200"
                     )
                     .run(context -> {
 
@@ -257,7 +252,7 @@ class AutoConfigIT {
                 .withBean(OpenAiOfficialChatModel.class, () -> customChatModel)
                 .withPropertyValues(
                         "langchain4j.open-ai-official.chat-model.api-key=test-key",
-                        "langchain4j.open-ai-official.chat-model.model-name=gpt-4o-mini"
+                        "langchain4j.open-ai-official.chat-model.model-name=gpt-5-mini"
                 )
                 .run(context -> {
                     assertThat(context).hasSingleBean(OpenAiOfficialChatModel.class);
@@ -272,7 +267,7 @@ class AutoConfigIT {
                 .withBean(OpenAiOfficialStreamingChatModel.class, () -> customModel)
                 .withPropertyValues(
                         "langchain4j.open-ai-official.streaming-chat-model.api-key=test-key",
-                        "langchain4j.open-ai-official.streaming-chat-model.model-name=gpt-4o-mini"
+                        "langchain4j.open-ai-official.streaming-chat-model.model-name=gpt-5-mini"
                 )
                 .run(context -> {
                     assertThat(context).hasSingleBean(OpenAiOfficialStreamingChatModel.class);
@@ -302,7 +297,7 @@ class AutoConfigIT {
                 .withBean(OpenAiOfficialImageModel.class, () -> customModel)
                 .withPropertyValues(
                         "langchain4j.open-ai-official.image-model.api-key=test-key",
-                        "langchain4j.open-ai-official.image-model.model-name=dall-e-3"
+                        "langchain4j.open-ai-official.image-model.model-name=gpt-image-1"
                 )
                 .run(context -> {
                     assertThat(context).hasSingleBean(OpenAiOfficialImageModel.class);

--- a/langchain4j-open-ai-official-spring-boot-starter/src/test/java/dev/langchain4j/openaiofficial/spring/AutoConfigIT.java
+++ b/langchain4j-open-ai-official-spring-boot-starter/src/test/java/dev/langchain4j/openaiofficial/spring/AutoConfigIT.java
@@ -1,0 +1,312 @@
+package dev.langchain4j.openaiofficial.spring;
+
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.image.ImageModel;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialChatModel;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialEmbeddingModel;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialImageModel;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialStreamingChatModel;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+
+class AutoConfigIT {
+
+    ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(AutoConfig.class));
+
+    @Nested
+    @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+    class OpenAi {
+
+        private static final String API_KEY = System.getenv("OPENAI_API_KEY");
+
+        @Test
+        void should_provide_chat_model() {
+            contextRunner
+                    .withPropertyValues(
+                            "langchain4j.open-ai-official.chat-model.api-key=" + API_KEY,
+                            "langchain4j.open-ai-official.chat-model.model-name=gpt-4o-mini",
+                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=20"
+                    )
+                    .run(context -> {
+
+                        ChatModel model = context.getBean(ChatModel.class);
+                        assertThat(model).isInstanceOf(OpenAiOfficialChatModel.class);
+                        assertThat(context.getBean(OpenAiOfficialChatModel.class)).isSameAs(model);
+
+                        assertThat(model.chat("What is the capital of Germany?")).contains("Berlin");
+                    });
+        }
+
+        @Test
+        void should_provide_chat_model_with_listeners() {
+            contextRunner
+                    .withPropertyValues(
+                            "langchain4j.open-ai-official.chat-model.api-key=" + API_KEY,
+                            "langchain4j.open-ai-official.chat-model.model-name=gpt-4o-mini",
+                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=20"
+                    )
+                    .withUserConfiguration(ListenerConfig.class)
+                    .run(context -> {
+
+                        ChatModel model = context.getBean(ChatModel.class);
+                        assertThat(model).isInstanceOf(OpenAiOfficialChatModel.class);
+
+                        assertThat(model.chat("What is the capital of Germany?")).contains("Berlin");
+
+                        ChatModelListener listener1 = context.getBean("listener1", ChatModelListener.class);
+                        ChatModelListener listener2 = context.getBean("listener2", ChatModelListener.class);
+                        InOrder inOrder = Mockito.inOrder(listener1, listener2);
+                        inOrder.verify(listener2).onRequest(any());
+                        inOrder.verify(listener1).onRequest(any());
+                        inOrder.verify(listener2).onResponse(any());
+                        inOrder.verify(listener1).onResponse(any());
+                        inOrder.verifyNoMoreInteractions();
+                    });
+        }
+
+        @Test
+        void should_provide_streaming_chat_model() {
+            contextRunner
+                    .withPropertyValues(
+                            "langchain4j.open-ai-official.streaming-chat-model.api-key=" + API_KEY,
+                            "langchain4j.open-ai-official.streaming-chat-model.model-name=gpt-4o-mini",
+                            "langchain4j.open-ai-official.streaming-chat-model.max-completion-tokens=20"
+                    )
+                    .run(context -> {
+
+                        StreamingChatModel model = context.getBean(StreamingChatModel.class);
+                        assertThat(model).isInstanceOf(OpenAiOfficialStreamingChatModel.class);
+                        assertThat(context.getBean(OpenAiOfficialStreamingChatModel.class)).isSameAs(model);
+
+                        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+                        model.chat("What is the capital of Germany?", new StreamingChatResponseHandler() {
+
+                            @Override
+                            public void onPartialResponse(String partialResponse) {
+                            }
+
+                            @Override
+                            public void onCompleteResponse(ChatResponse completeResponse) {
+                                future.complete(completeResponse);
+                            }
+
+                            @Override
+                            public void onError(Throwable error) {
+                                future.completeExceptionally(error);
+                            }
+                        });
+                        ChatResponse chatResponse = future.get(30, SECONDS);
+                        assertThat(chatResponse.aiMessage().text()).contains("Berlin");
+                    });
+        }
+    }
+
+    @Nested
+    @EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_API_KEY", matches = ".+")
+    class AzureOpenAi {
+
+        private static final String AZURE_ENDPOINT = System.getenv("AZURE_OPENAI_ENDPOINT");
+        private static final String API_KEY = System.getenv("AZURE_OPENAI_API_KEY");
+        private static final String DEPLOYMENT_NAME = System.getenv("AZURE_OPENAI_DEPLOYMENT_NAME");
+
+        @Test
+        void should_provide_chat_model() {
+            contextRunner
+                    .withPropertyValues(
+                            "langchain4j.open-ai-official.chat-model.base-url=" + AZURE_ENDPOINT,
+                            "langchain4j.open-ai-official.chat-model.api-key=" + API_KEY,
+                            "langchain4j.open-ai-official.chat-model.is-microsoft-foundry=true",
+                            "langchain4j.open-ai-official.chat-model.microsoft-foundry-deployment-name=" + DEPLOYMENT_NAME,
+                            "langchain4j.open-ai-official.chat-model.model-name=" + DEPLOYMENT_NAME,
+                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=20"
+                    )
+                    .run(context -> {
+
+                        ChatModel model = context.getBean(ChatModel.class);
+                        assertThat(model).isInstanceOf(OpenAiOfficialChatModel.class);
+                        assertThat(context.getBean(OpenAiOfficialChatModel.class)).isSameAs(model);
+
+                        assertThat(model.chat("What is the capital of Germany?")).contains("Berlin");
+                    });
+        }
+
+        @Test
+        void should_provide_chat_model_with_listeners() {
+            contextRunner
+                    .withPropertyValues(
+                            "langchain4j.open-ai-official.chat-model.base-url=" + AZURE_ENDPOINT,
+                            "langchain4j.open-ai-official.chat-model.api-key=" + API_KEY,
+                            "langchain4j.open-ai-official.chat-model.is-microsoft-foundry=true",
+                            "langchain4j.open-ai-official.chat-model.microsoft-foundry-deployment-name=" + DEPLOYMENT_NAME,
+                            "langchain4j.open-ai-official.chat-model.model-name=" + DEPLOYMENT_NAME,
+                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=20"
+                    )
+                    .withUserConfiguration(ListenerConfig.class)
+                    .run(context -> {
+
+                        ChatModel model = context.getBean(ChatModel.class);
+                        assertThat(model).isInstanceOf(OpenAiOfficialChatModel.class);
+
+                        assertThat(model.chat("What is the capital of Germany?")).contains("Berlin");
+
+                        ChatModelListener listener1 = context.getBean("listener1", ChatModelListener.class);
+                        ChatModelListener listener2 = context.getBean("listener2", ChatModelListener.class);
+                        InOrder inOrder = Mockito.inOrder(listener1, listener2);
+                        inOrder.verify(listener2).onRequest(any());
+                        inOrder.verify(listener1).onRequest(any());
+                        inOrder.verify(listener2).onResponse(any());
+                        inOrder.verify(listener1).onResponse(any());
+                        inOrder.verifyNoMoreInteractions();
+                    });
+        }
+
+        @Test
+        void should_provide_streaming_chat_model() {
+            contextRunner
+                    .withPropertyValues(
+                            "langchain4j.open-ai-official.streaming-chat-model.base-url=" + AZURE_ENDPOINT,
+                            "langchain4j.open-ai-official.streaming-chat-model.api-key=" + API_KEY,
+                            "langchain4j.open-ai-official.streaming-chat-model.is-microsoft-foundry=true",
+                            "langchain4j.open-ai-official.streaming-chat-model.microsoft-foundry-deployment-name=" + DEPLOYMENT_NAME,
+                            "langchain4j.open-ai-official.streaming-chat-model.model-name=" + DEPLOYMENT_NAME,
+                            "langchain4j.open-ai-official.streaming-chat-model.max-completion-tokens=20"
+                    )
+                    .run(context -> {
+
+                        StreamingChatModel model = context.getBean(StreamingChatModel.class);
+                        assertThat(model).isInstanceOf(OpenAiOfficialStreamingChatModel.class);
+                        assertThat(context.getBean(OpenAiOfficialStreamingChatModel.class)).isSameAs(model);
+
+                        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+                        model.chat("What is the capital of Germany?", new StreamingChatResponseHandler() {
+
+                            @Override
+                            public void onPartialResponse(String partialResponse) {
+                            }
+
+                            @Override
+                            public void onCompleteResponse(ChatResponse completeResponse) {
+                                future.complete(completeResponse);
+                            }
+
+                            @Override
+                            public void onError(Throwable error) {
+                                future.completeExceptionally(error);
+                            }
+                        });
+                        ChatResponse chatResponse = future.get(30, SECONDS);
+                        assertThat(chatResponse.aiMessage().text()).contains("Berlin");
+                    });
+        }
+    }
+
+    @Configuration
+    static class ListenerConfig {
+
+        @Bean
+        @Order(2)
+        ChatModelListener listener1() {
+            return mock(ChatModelListener.class);
+        }
+
+        @Bean
+        @Order(1)
+        ChatModelListener listener2() {
+            return mock(ChatModelListener.class);
+        }
+    }
+
+    // --- Tests that don't require API calls ---
+
+    @Test
+    void should_not_create_beans_when_api_key_is_not_set() {
+        contextRunner
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(OpenAiOfficialChatModel.class);
+                    assertThat(context).doesNotHaveBean(OpenAiOfficialStreamingChatModel.class);
+                    assertThat(context).doesNotHaveBean(OpenAiOfficialEmbeddingModel.class);
+                    assertThat(context).doesNotHaveBean(OpenAiOfficialImageModel.class);
+                });
+    }
+
+    @Test
+    void should_not_create_chat_model_when_user_provides_own_bean() {
+        OpenAiOfficialChatModel customChatModel = mock(OpenAiOfficialChatModel.class);
+        contextRunner
+                .withBean(OpenAiOfficialChatModel.class, () -> customChatModel)
+                .withPropertyValues(
+                        "langchain4j.open-ai-official.chat-model.api-key=test-key",
+                        "langchain4j.open-ai-official.chat-model.model-name=gpt-4o-mini"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(OpenAiOfficialChatModel.class);
+                    assertThat(context.getBean(OpenAiOfficialChatModel.class)).isSameAs(customChatModel);
+                });
+    }
+
+    @Test
+    void should_not_create_streaming_chat_model_when_user_provides_own_bean() {
+        OpenAiOfficialStreamingChatModel customModel = mock(OpenAiOfficialStreamingChatModel.class);
+        contextRunner
+                .withBean(OpenAiOfficialStreamingChatModel.class, () -> customModel)
+                .withPropertyValues(
+                        "langchain4j.open-ai-official.streaming-chat-model.api-key=test-key",
+                        "langchain4j.open-ai-official.streaming-chat-model.model-name=gpt-4o-mini"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(OpenAiOfficialStreamingChatModel.class);
+                    assertThat(context.getBean(OpenAiOfficialStreamingChatModel.class)).isSameAs(customModel);
+                });
+    }
+
+    @Test
+    void should_not_create_embedding_model_when_user_provides_own_bean() {
+        OpenAiOfficialEmbeddingModel customModel = mock(OpenAiOfficialEmbeddingModel.class);
+        contextRunner
+                .withBean(OpenAiOfficialEmbeddingModel.class, () -> customModel)
+                .withPropertyValues(
+                        "langchain4j.open-ai-official.embedding-model.api-key=test-key",
+                        "langchain4j.open-ai-official.embedding-model.model-name=text-embedding-3-small"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(OpenAiOfficialEmbeddingModel.class);
+                    assertThat(context.getBean(OpenAiOfficialEmbeddingModel.class)).isSameAs(customModel);
+                });
+    }
+
+    @Test
+    void should_not_create_image_model_when_user_provides_own_bean() {
+        OpenAiOfficialImageModel customModel = mock(OpenAiOfficialImageModel.class);
+        contextRunner
+                .withBean(OpenAiOfficialImageModel.class, () -> customModel)
+                .withPropertyValues(
+                        "langchain4j.open-ai-official.image-model.api-key=test-key",
+                        "langchain4j.open-ai-official.image-model.model-name=dall-e-3"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(OpenAiOfficialImageModel.class);
+                    assertThat(context.getBean(OpenAiOfficialImageModel.class)).isSameAs(customModel);
+                });
+    }
+}

--- a/langchain4j-open-ai-official-spring-boot4-starter/pom.xml
+++ b/langchain4j-open-ai-official-spring-boot4-starter/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-spring</artifactId>
+        <version>1.14.0-beta24-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>langchain4j-open-ai-official-spring-boot4-starter</artifactId>
+    <name>LangChain4j Spring Boot 4 starter for OpenAI Official</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Override Spring Boot version from parent -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot4.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-open-ai-official</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- needed to generate automatic metadata about available config properties -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/langchain4j-open-ai-official-spring-boot4-starter/src/main/java/dev/langchain4j/openaiofficial/spring/OpenAiOfficialAutoConfiguration.java
+++ b/langchain4j-open-ai-official-spring-boot4-starter/src/main/java/dev/langchain4j/openaiofficial/spring/OpenAiOfficialAutoConfiguration.java
@@ -1,0 +1,141 @@
+package dev.langchain4j.openaiofficial.spring;
+
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialChatModel;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialChatRequestParameters;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialEmbeddingModel;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialImageModel;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialStreamingChatModel;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+import static dev.langchain4j.openaiofficial.spring.OpenAiOfficialProperties.PREFIX;
+
+@AutoConfiguration
+@EnableConfigurationProperties(OpenAiOfficialProperties.class)
+public class OpenAiOfficialAutoConfiguration {
+
+    @Bean
+    @ConditionalOnProperty(PREFIX + ".chat-model.api-key")
+    @ConditionalOnMissingBean
+    OpenAiOfficialChatModel openAiOfficialChatModel(OpenAiOfficialProperties properties,
+                                                     ObjectProvider<ChatModelListener> listeners) {
+        OpenAiOfficialChatModelProperties chatModelProperties = properties.chatModel();
+        return OpenAiOfficialChatModel.builder()
+                .baseUrl(chatModelProperties.baseUrl())
+                .apiKey(chatModelProperties.apiKey())
+                .organizationId(chatModelProperties.organizationId())
+                .isMicrosoftFoundry(Boolean.TRUE.equals(chatModelProperties.isMicrosoftFoundry()))
+                .microsoftFoundryDeploymentName(chatModelProperties.microsoftFoundryDeploymentName())
+                .modelName(chatModelProperties.modelName())
+                .temperature(chatModelProperties.temperature())
+                .topP(chatModelProperties.topP())
+                .stop(chatModelProperties.stop())
+                .maxCompletionTokens(chatModelProperties.maxCompletionTokens())
+                .presencePenalty(chatModelProperties.presencePenalty())
+                .frequencyPenalty(chatModelProperties.frequencyPenalty())
+                .logitBias(chatModelProperties.logitBias())
+                .responseFormat(chatModelProperties.responseFormat())
+                .strictJsonSchema(chatModelProperties.strictJsonSchema())
+                .seed(chatModelProperties.seed())
+                .user(chatModelProperties.user())
+                .strictTools(chatModelProperties.strictTools())
+                .parallelToolCalls(chatModelProperties.parallelToolCalls())
+                .store(chatModelProperties.store())
+                .metadata(chatModelProperties.metadata())
+                .serviceTier(chatModelProperties.serviceTier())
+                .supportedCapabilities(chatModelProperties.supportedCapabilities())
+                .defaultRequestParameters(OpenAiOfficialChatRequestParameters.builder()
+                        .reasoningEffort(chatModelProperties.reasoningEffort())
+                        .build())
+                .timeout(chatModelProperties.timeout())
+                .maxRetries(chatModelProperties.maxRetries())
+                .customHeaders(chatModelProperties.customHeaders())
+                .listeners(listeners.orderedStream().toList())
+                .build();
+    }
+
+    @Bean
+    @ConditionalOnProperty(PREFIX + ".streaming-chat-model.api-key")
+    @ConditionalOnMissingBean
+    OpenAiOfficialStreamingChatModel openAiOfficialStreamingChatModel(OpenAiOfficialProperties properties,
+                                                                      ObjectProvider<ChatModelListener> listeners) {
+        OpenAiOfficialChatModelProperties chatModelProperties = properties.streamingChatModel();
+        return OpenAiOfficialStreamingChatModel.builder()
+                .baseUrl(chatModelProperties.baseUrl())
+                .apiKey(chatModelProperties.apiKey())
+                .organizationId(chatModelProperties.organizationId())
+                .isMicrosoftFoundry(Boolean.TRUE.equals(chatModelProperties.isMicrosoftFoundry()))
+                .microsoftFoundryDeploymentName(chatModelProperties.microsoftFoundryDeploymentName())
+                .modelName(chatModelProperties.modelName())
+                .temperature(chatModelProperties.temperature())
+                .topP(chatModelProperties.topP())
+                .stop(chatModelProperties.stop())
+                .maxCompletionTokens(chatModelProperties.maxCompletionTokens())
+                .presencePenalty(chatModelProperties.presencePenalty())
+                .frequencyPenalty(chatModelProperties.frequencyPenalty())
+                .logitBias(chatModelProperties.logitBias())
+                .responseFormat(chatModelProperties.responseFormat())
+                .strictJsonSchema(chatModelProperties.strictJsonSchema())
+                .seed(chatModelProperties.seed())
+                .user(chatModelProperties.user())
+                .strictTools(chatModelProperties.strictTools())
+                .parallelToolCalls(chatModelProperties.parallelToolCalls())
+                .store(chatModelProperties.store())
+                .metadata(chatModelProperties.metadata())
+                .serviceTier(chatModelProperties.serviceTier())
+                .supportedCapabilities(chatModelProperties.supportedCapabilities())
+                .defaultRequestParameters(OpenAiOfficialChatRequestParameters.builder()
+                        .reasoningEffort(chatModelProperties.reasoningEffort())
+                        .build())
+                .timeout(chatModelProperties.timeout())
+                .maxRetries(chatModelProperties.maxRetries())
+                .customHeaders(chatModelProperties.customHeaders())
+                .listeners(listeners.orderedStream().toList())
+                .build();
+    }
+
+    @Bean
+    @ConditionalOnProperty(PREFIX + ".embedding-model.api-key")
+    @ConditionalOnMissingBean
+    OpenAiOfficialEmbeddingModel openAiOfficialEmbeddingModel(OpenAiOfficialProperties properties) {
+        OpenAiOfficialEmbeddingModelProperties embeddingModelProperties = properties.embeddingModel();
+        return OpenAiOfficialEmbeddingModel.builder()
+                .baseUrl(embeddingModelProperties.baseUrl())
+                .apiKey(embeddingModelProperties.apiKey())
+                .organizationId(embeddingModelProperties.organizationId())
+                .modelName(embeddingModelProperties.modelName())
+                .dimensions(embeddingModelProperties.dimensions())
+                .user(embeddingModelProperties.user())
+                .maxSegmentsPerBatch(embeddingModelProperties.maxSegmentsPerBatch())
+                .timeout(embeddingModelProperties.timeout())
+                .maxRetries(embeddingModelProperties.maxRetries())
+                .customHeaders(embeddingModelProperties.customHeaders())
+                .build();
+    }
+
+    @Bean
+    @ConditionalOnProperty(PREFIX + ".image-model.api-key")
+    @ConditionalOnMissingBean
+    OpenAiOfficialImageModel openAiOfficialImageModel(OpenAiOfficialProperties properties) {
+        OpenAiOfficialImageModelProperties imageModelProperties = properties.imageModel();
+        return OpenAiOfficialImageModel.builder()
+                .baseUrl(imageModelProperties.baseUrl())
+                .apiKey(imageModelProperties.apiKey())
+                .organizationId(imageModelProperties.organizationId())
+                .modelName(imageModelProperties.modelName())
+                .size(imageModelProperties.size())
+                .quality(imageModelProperties.quality())
+                .style(imageModelProperties.style())
+                .user(imageModelProperties.user())
+                .responseFormat(imageModelProperties.responseFormat())
+                .timeout(imageModelProperties.timeout())
+                .maxRetries(imageModelProperties.maxRetries())
+                .customHeaders(imageModelProperties.customHeaders())
+                .build();
+    }
+}

--- a/langchain4j-open-ai-official-spring-boot4-starter/src/main/java/dev/langchain4j/openaiofficial/spring/OpenAiOfficialChatModelProperties.java
+++ b/langchain4j-open-ai-official-spring-boot4-starter/src/main/java/dev/langchain4j/openaiofficial/spring/OpenAiOfficialChatModelProperties.java
@@ -1,0 +1,39 @@
+package dev.langchain4j.openaiofficial.spring;
+
+import dev.langchain4j.model.chat.Capability;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+record OpenAiOfficialChatModelProperties(
+        String baseUrl,
+        String apiKey,
+        String organizationId,
+        Boolean isMicrosoftFoundry,
+        String microsoftFoundryDeploymentName,
+        String modelName,
+        Double temperature,
+        Double topP,
+        List<String> stop,
+        Integer maxCompletionTokens,
+        Double presencePenalty,
+        Double frequencyPenalty,
+        Map<String, Integer> logitBias,
+        String responseFormat,
+        Boolean strictJsonSchema,
+        Integer seed,
+        String user,
+        Boolean strictTools,
+        Boolean parallelToolCalls,
+        Boolean store,
+        Map<String, String> metadata,
+        String serviceTier,
+        String reasoningEffort,
+        Set<Capability> supportedCapabilities,
+        Duration timeout,
+        Integer maxRetries,
+        Map<String, String> customHeaders
+) {
+}

--- a/langchain4j-open-ai-official-spring-boot4-starter/src/main/java/dev/langchain4j/openaiofficial/spring/OpenAiOfficialEmbeddingModelProperties.java
+++ b/langchain4j-open-ai-official-spring-boot4-starter/src/main/java/dev/langchain4j/openaiofficial/spring/OpenAiOfficialEmbeddingModelProperties.java
@@ -1,0 +1,18 @@
+package dev.langchain4j.openaiofficial.spring;
+
+import java.time.Duration;
+import java.util.Map;
+
+record OpenAiOfficialEmbeddingModelProperties(
+        String baseUrl,
+        String apiKey,
+        String organizationId,
+        String modelName,
+        Integer dimensions,
+        String user,
+        Integer maxSegmentsPerBatch,
+        Duration timeout,
+        Integer maxRetries,
+        Map<String, String> customHeaders
+) {
+}

--- a/langchain4j-open-ai-official-spring-boot4-starter/src/main/java/dev/langchain4j/openaiofficial/spring/OpenAiOfficialImageModelProperties.java
+++ b/langchain4j-open-ai-official-spring-boot4-starter/src/main/java/dev/langchain4j/openaiofficial/spring/OpenAiOfficialImageModelProperties.java
@@ -1,0 +1,20 @@
+package dev.langchain4j.openaiofficial.spring;
+
+import java.time.Duration;
+import java.util.Map;
+
+record OpenAiOfficialImageModelProperties(
+        String baseUrl,
+        String apiKey,
+        String organizationId,
+        String modelName,
+        String size,
+        String quality,
+        String style,
+        String user,
+        String responseFormat,
+        Duration timeout,
+        Integer maxRetries,
+        Map<String, String> customHeaders
+) {
+}

--- a/langchain4j-open-ai-official-spring-boot4-starter/src/main/java/dev/langchain4j/openaiofficial/spring/OpenAiOfficialProperties.java
+++ b/langchain4j-open-ai-official-spring-boot4-starter/src/main/java/dev/langchain4j/openaiofficial/spring/OpenAiOfficialProperties.java
@@ -1,0 +1,23 @@
+package dev.langchain4j.openaiofficial.spring;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+@ConfigurationProperties(prefix = OpenAiOfficialProperties.PREFIX)
+public record OpenAiOfficialProperties(
+
+    @NestedConfigurationProperty
+    OpenAiOfficialChatModelProperties chatModel,
+
+    @NestedConfigurationProperty
+    OpenAiOfficialChatModelProperties streamingChatModel,
+
+    @NestedConfigurationProperty
+    OpenAiOfficialEmbeddingModelProperties embeddingModel,
+
+    @NestedConfigurationProperty
+    OpenAiOfficialImageModelProperties imageModel
+) {
+    static final String PREFIX = "langchain4j.open-ai-official";
+
+}

--- a/langchain4j-open-ai-official-spring-boot4-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/langchain4j-open-ai-official-spring-boot4-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.langchain4j.openaiofficial.spring.OpenAiOfficialAutoConfiguration

--- a/langchain4j-open-ai-official-spring-boot4-starter/src/test/java/dev/langchain4j/openaiofficial/spring/OpenAiOfficialAutoConfigurationIT.java
+++ b/langchain4j-open-ai-official-spring-boot4-starter/src/test/java/dev/langchain4j/openaiofficial/spring/OpenAiOfficialAutoConfigurationIT.java
@@ -1,0 +1,312 @@
+package dev.langchain4j.openaiofficial.spring;
+
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.image.ImageModel;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialChatModel;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialEmbeddingModel;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialImageModel;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialStreamingChatModel;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+
+class OpenAiOfficialAutoConfigurationIT {
+
+    ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(OpenAiOfficialAutoConfiguration.class));
+
+    @Nested
+    @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+    class OpenAi {
+
+        private static final String API_KEY = System.getenv("OPENAI_API_KEY");
+
+        @Test
+        void should_provide_chat_model() {
+            contextRunner
+                    .withPropertyValues(
+                            "langchain4j.open-ai-official.chat-model.api-key=" + API_KEY,
+                            "langchain4j.open-ai-official.chat-model.model-name=gpt-4o-mini",
+                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=20"
+                    )
+                    .run(context -> {
+
+                        ChatModel model = context.getBean(ChatModel.class);
+                        assertThat(model).isInstanceOf(OpenAiOfficialChatModel.class);
+                        assertThat(context.getBean(OpenAiOfficialChatModel.class)).isSameAs(model);
+
+                        assertThat(model.chat("What is the capital of Germany?")).contains("Berlin");
+                    });
+        }
+
+        @Test
+        void should_provide_chat_model_with_listeners() {
+            contextRunner
+                    .withPropertyValues(
+                            "langchain4j.open-ai-official.chat-model.api-key=" + API_KEY,
+                            "langchain4j.open-ai-official.chat-model.model-name=gpt-4o-mini",
+                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=20"
+                    )
+                    .withUserConfiguration(ListenerConfig.class)
+                    .run(context -> {
+
+                        ChatModel model = context.getBean(ChatModel.class);
+                        assertThat(model).isInstanceOf(OpenAiOfficialChatModel.class);
+
+                        assertThat(model.chat("What is the capital of Germany?")).contains("Berlin");
+
+                        ChatModelListener listener1 = context.getBean("listener1", ChatModelListener.class);
+                        ChatModelListener listener2 = context.getBean("listener2", ChatModelListener.class);
+                        InOrder inOrder = Mockito.inOrder(listener1, listener2);
+                        inOrder.verify(listener2).onRequest(any());
+                        inOrder.verify(listener1).onRequest(any());
+                        inOrder.verify(listener2).onResponse(any());
+                        inOrder.verify(listener1).onResponse(any());
+                        inOrder.verifyNoMoreInteractions();
+                    });
+        }
+
+        @Test
+        void should_provide_streaming_chat_model() {
+            contextRunner
+                    .withPropertyValues(
+                            "langchain4j.open-ai-official.streaming-chat-model.api-key=" + API_KEY,
+                            "langchain4j.open-ai-official.streaming-chat-model.model-name=gpt-4o-mini",
+                            "langchain4j.open-ai-official.streaming-chat-model.max-completion-tokens=20"
+                    )
+                    .run(context -> {
+
+                        StreamingChatModel model = context.getBean(StreamingChatModel.class);
+                        assertThat(model).isInstanceOf(OpenAiOfficialStreamingChatModel.class);
+                        assertThat(context.getBean(OpenAiOfficialStreamingChatModel.class)).isSameAs(model);
+
+                        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+                        model.chat("What is the capital of Germany?", new StreamingChatResponseHandler() {
+
+                            @Override
+                            public void onPartialResponse(String partialResponse) {
+                            }
+
+                            @Override
+                            public void onCompleteResponse(ChatResponse completeResponse) {
+                                future.complete(completeResponse);
+                            }
+
+                            @Override
+                            public void onError(Throwable error) {
+                                future.completeExceptionally(error);
+                            }
+                        });
+                        ChatResponse chatResponse = future.get(30, SECONDS);
+                        assertThat(chatResponse.aiMessage().text()).contains("Berlin");
+                    });
+        }
+    }
+
+    @Nested
+    @EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_API_KEY", matches = ".+")
+    class AzureOpenAi {
+
+        private static final String AZURE_ENDPOINT = System.getenv("AZURE_OPENAI_ENDPOINT");
+        private static final String API_KEY = System.getenv("AZURE_OPENAI_API_KEY");
+        private static final String DEPLOYMENT_NAME = System.getenv("AZURE_OPENAI_DEPLOYMENT_NAME");
+
+        @Test
+        void should_provide_chat_model() {
+            contextRunner
+                    .withPropertyValues(
+                            "langchain4j.open-ai-official.chat-model.base-url=" + AZURE_ENDPOINT,
+                            "langchain4j.open-ai-official.chat-model.api-key=" + API_KEY,
+                            "langchain4j.open-ai-official.chat-model.is-microsoft-foundry=true",
+                            "langchain4j.open-ai-official.chat-model.microsoft-foundry-deployment-name=" + DEPLOYMENT_NAME,
+                            "langchain4j.open-ai-official.chat-model.model-name=" + DEPLOYMENT_NAME,
+                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=20"
+                    )
+                    .run(context -> {
+
+                        ChatModel model = context.getBean(ChatModel.class);
+                        assertThat(model).isInstanceOf(OpenAiOfficialChatModel.class);
+                        assertThat(context.getBean(OpenAiOfficialChatModel.class)).isSameAs(model);
+
+                        assertThat(model.chat("What is the capital of Germany?")).contains("Berlin");
+                    });
+        }
+
+        @Test
+        void should_provide_chat_model_with_listeners() {
+            contextRunner
+                    .withPropertyValues(
+                            "langchain4j.open-ai-official.chat-model.base-url=" + AZURE_ENDPOINT,
+                            "langchain4j.open-ai-official.chat-model.api-key=" + API_KEY,
+                            "langchain4j.open-ai-official.chat-model.is-microsoft-foundry=true",
+                            "langchain4j.open-ai-official.chat-model.microsoft-foundry-deployment-name=" + DEPLOYMENT_NAME,
+                            "langchain4j.open-ai-official.chat-model.model-name=" + DEPLOYMENT_NAME,
+                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=20"
+                    )
+                    .withUserConfiguration(ListenerConfig.class)
+                    .run(context -> {
+
+                        ChatModel model = context.getBean(ChatModel.class);
+                        assertThat(model).isInstanceOf(OpenAiOfficialChatModel.class);
+
+                        assertThat(model.chat("What is the capital of Germany?")).contains("Berlin");
+
+                        ChatModelListener listener1 = context.getBean("listener1", ChatModelListener.class);
+                        ChatModelListener listener2 = context.getBean("listener2", ChatModelListener.class);
+                        InOrder inOrder = Mockito.inOrder(listener1, listener2);
+                        inOrder.verify(listener2).onRequest(any());
+                        inOrder.verify(listener1).onRequest(any());
+                        inOrder.verify(listener2).onResponse(any());
+                        inOrder.verify(listener1).onResponse(any());
+                        inOrder.verifyNoMoreInteractions();
+                    });
+        }
+
+        @Test
+        void should_provide_streaming_chat_model() {
+            contextRunner
+                    .withPropertyValues(
+                            "langchain4j.open-ai-official.streaming-chat-model.base-url=" + AZURE_ENDPOINT,
+                            "langchain4j.open-ai-official.streaming-chat-model.api-key=" + API_KEY,
+                            "langchain4j.open-ai-official.streaming-chat-model.is-microsoft-foundry=true",
+                            "langchain4j.open-ai-official.streaming-chat-model.microsoft-foundry-deployment-name=" + DEPLOYMENT_NAME,
+                            "langchain4j.open-ai-official.streaming-chat-model.model-name=" + DEPLOYMENT_NAME,
+                            "langchain4j.open-ai-official.streaming-chat-model.max-completion-tokens=20"
+                    )
+                    .run(context -> {
+
+                        StreamingChatModel model = context.getBean(StreamingChatModel.class);
+                        assertThat(model).isInstanceOf(OpenAiOfficialStreamingChatModel.class);
+                        assertThat(context.getBean(OpenAiOfficialStreamingChatModel.class)).isSameAs(model);
+
+                        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+                        model.chat("What is the capital of Germany?", new StreamingChatResponseHandler() {
+
+                            @Override
+                            public void onPartialResponse(String partialResponse) {
+                            }
+
+                            @Override
+                            public void onCompleteResponse(ChatResponse completeResponse) {
+                                future.complete(completeResponse);
+                            }
+
+                            @Override
+                            public void onError(Throwable error) {
+                                future.completeExceptionally(error);
+                            }
+                        });
+                        ChatResponse chatResponse = future.get(30, SECONDS);
+                        assertThat(chatResponse.aiMessage().text()).contains("Berlin");
+                    });
+        }
+    }
+
+    @Configuration
+    static class ListenerConfig {
+
+        @Bean
+        @Order(2)
+        ChatModelListener listener1() {
+            return mock(ChatModelListener.class);
+        }
+
+        @Bean
+        @Order(1)
+        ChatModelListener listener2() {
+            return mock(ChatModelListener.class);
+        }
+    }
+
+    // --- Tests that don't require API calls ---
+
+    @Test
+    void should_not_create_beans_when_api_key_is_not_set() {
+        contextRunner
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(OpenAiOfficialChatModel.class);
+                    assertThat(context).doesNotHaveBean(OpenAiOfficialStreamingChatModel.class);
+                    assertThat(context).doesNotHaveBean(OpenAiOfficialEmbeddingModel.class);
+                    assertThat(context).doesNotHaveBean(OpenAiOfficialImageModel.class);
+                });
+    }
+
+    @Test
+    void should_not_create_chat_model_when_user_provides_own_bean() {
+        OpenAiOfficialChatModel customChatModel = mock(OpenAiOfficialChatModel.class);
+        contextRunner
+                .withBean(OpenAiOfficialChatModel.class, () -> customChatModel)
+                .withPropertyValues(
+                        "langchain4j.open-ai-official.chat-model.api-key=test-key",
+                        "langchain4j.open-ai-official.chat-model.model-name=gpt-4o-mini"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(OpenAiOfficialChatModel.class);
+                    assertThat(context.getBean(OpenAiOfficialChatModel.class)).isSameAs(customChatModel);
+                });
+    }
+
+    @Test
+    void should_not_create_streaming_chat_model_when_user_provides_own_bean() {
+        OpenAiOfficialStreamingChatModel customModel = mock(OpenAiOfficialStreamingChatModel.class);
+        contextRunner
+                .withBean(OpenAiOfficialStreamingChatModel.class, () -> customModel)
+                .withPropertyValues(
+                        "langchain4j.open-ai-official.streaming-chat-model.api-key=test-key",
+                        "langchain4j.open-ai-official.streaming-chat-model.model-name=gpt-4o-mini"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(OpenAiOfficialStreamingChatModel.class);
+                    assertThat(context.getBean(OpenAiOfficialStreamingChatModel.class)).isSameAs(customModel);
+                });
+    }
+
+    @Test
+    void should_not_create_embedding_model_when_user_provides_own_bean() {
+        OpenAiOfficialEmbeddingModel customModel = mock(OpenAiOfficialEmbeddingModel.class);
+        contextRunner
+                .withBean(OpenAiOfficialEmbeddingModel.class, () -> customModel)
+                .withPropertyValues(
+                        "langchain4j.open-ai-official.embedding-model.api-key=test-key",
+                        "langchain4j.open-ai-official.embedding-model.model-name=text-embedding-3-small"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(OpenAiOfficialEmbeddingModel.class);
+                    assertThat(context.getBean(OpenAiOfficialEmbeddingModel.class)).isSameAs(customModel);
+                });
+    }
+
+    @Test
+    void should_not_create_image_model_when_user_provides_own_bean() {
+        OpenAiOfficialImageModel customModel = mock(OpenAiOfficialImageModel.class);
+        contextRunner
+                .withBean(OpenAiOfficialImageModel.class, () -> customModel)
+                .withPropertyValues(
+                        "langchain4j.open-ai-official.image-model.api-key=test-key",
+                        "langchain4j.open-ai-official.image-model.model-name=dall-e-3"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(OpenAiOfficialImageModel.class);
+                    assertThat(context.getBean(OpenAiOfficialImageModel.class)).isSameAs(customModel);
+                });
+    }
+}

--- a/langchain4j-open-ai-official-spring-boot4-starter/src/test/java/dev/langchain4j/openaiofficial/spring/OpenAiOfficialAutoConfigurationIT.java
+++ b/langchain4j-open-ai-official-spring-boot4-starter/src/test/java/dev/langchain4j/openaiofficial/spring/OpenAiOfficialAutoConfigurationIT.java
@@ -39,14 +39,15 @@ class OpenAiOfficialAutoConfigurationIT {
     class OpenAi {
 
         private static final String API_KEY = System.getenv("OPENAI_API_KEY");
+        private static final String MODEL_NAME = "gpt-5-mini";
 
         @Test
         void should_provide_chat_model() {
             contextRunner
                     .withPropertyValues(
                             "langchain4j.open-ai-official.chat-model.api-key=" + API_KEY,
-                            "langchain4j.open-ai-official.chat-model.model-name=gpt-4o-mini",
-                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=20"
+                            "langchain4j.open-ai-official.chat-model.model-name=" + MODEL_NAME,
+                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=200"
                     )
                     .run(context -> {
 
@@ -63,8 +64,8 @@ class OpenAiOfficialAutoConfigurationIT {
             contextRunner
                     .withPropertyValues(
                             "langchain4j.open-ai-official.chat-model.api-key=" + API_KEY,
-                            "langchain4j.open-ai-official.chat-model.model-name=gpt-4o-mini",
-                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=20"
+                            "langchain4j.open-ai-official.chat-model.model-name=" + MODEL_NAME,
+                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=200"
                     )
                     .withUserConfiguration(ListenerConfig.class)
                     .run(context -> {
@@ -90,8 +91,8 @@ class OpenAiOfficialAutoConfigurationIT {
             contextRunner
                     .withPropertyValues(
                             "langchain4j.open-ai-official.streaming-chat-model.api-key=" + API_KEY,
-                            "langchain4j.open-ai-official.streaming-chat-model.model-name=gpt-4o-mini",
-                            "langchain4j.open-ai-official.streaming-chat-model.max-completion-tokens=20"
+                            "langchain4j.open-ai-official.streaming-chat-model.model-name=" + MODEL_NAME,
+                            "langchain4j.open-ai-official.streaming-chat-model.max-completion-tokens=200"
                     )
                     .run(context -> {
 
@@ -123,23 +124,21 @@ class OpenAiOfficialAutoConfigurationIT {
     }
 
     @Nested
-    @EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_API_KEY", matches = ".+")
-    class AzureOpenAi {
+    @EnabledIfEnvironmentVariable(named = "MICROSOFT_FOUNDRY_API_KEY", matches = ".+")
+    class MicrosoftFoundry {
 
-        private static final String AZURE_ENDPOINT = System.getenv("AZURE_OPENAI_ENDPOINT");
-        private static final String API_KEY = System.getenv("AZURE_OPENAI_API_KEY");
-        private static final String DEPLOYMENT_NAME = System.getenv("AZURE_OPENAI_DEPLOYMENT_NAME");
+        private static final String ENDPOINT = System.getenv("MICROSOFT_FOUNDRY_ENDPOINT");
+        private static final String API_KEY = System.getenv("MICROSOFT_FOUNDRY_API_KEY");
+        private static final String MODEL_NAME = "gpt-5-mini";
 
         @Test
         void should_provide_chat_model() {
             contextRunner
                     .withPropertyValues(
-                            "langchain4j.open-ai-official.chat-model.base-url=" + AZURE_ENDPOINT,
+                            "langchain4j.open-ai-official.chat-model.base-url=" + ENDPOINT,
                             "langchain4j.open-ai-official.chat-model.api-key=" + API_KEY,
-                            "langchain4j.open-ai-official.chat-model.is-microsoft-foundry=true",
-                            "langchain4j.open-ai-official.chat-model.microsoft-foundry-deployment-name=" + DEPLOYMENT_NAME,
-                            "langchain4j.open-ai-official.chat-model.model-name=" + DEPLOYMENT_NAME,
-                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=20"
+                            "langchain4j.open-ai-official.chat-model.model-name=" + MODEL_NAME,
+                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=200"
                     )
                     .run(context -> {
 
@@ -155,12 +154,10 @@ class OpenAiOfficialAutoConfigurationIT {
         void should_provide_chat_model_with_listeners() {
             contextRunner
                     .withPropertyValues(
-                            "langchain4j.open-ai-official.chat-model.base-url=" + AZURE_ENDPOINT,
+                            "langchain4j.open-ai-official.chat-model.base-url=" + ENDPOINT,
                             "langchain4j.open-ai-official.chat-model.api-key=" + API_KEY,
-                            "langchain4j.open-ai-official.chat-model.is-microsoft-foundry=true",
-                            "langchain4j.open-ai-official.chat-model.microsoft-foundry-deployment-name=" + DEPLOYMENT_NAME,
-                            "langchain4j.open-ai-official.chat-model.model-name=" + DEPLOYMENT_NAME,
-                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=20"
+                            "langchain4j.open-ai-official.chat-model.model-name=" + MODEL_NAME,
+                            "langchain4j.open-ai-official.chat-model.max-completion-tokens=200"
                     )
                     .withUserConfiguration(ListenerConfig.class)
                     .run(context -> {
@@ -185,12 +182,10 @@ class OpenAiOfficialAutoConfigurationIT {
         void should_provide_streaming_chat_model() {
             contextRunner
                     .withPropertyValues(
-                            "langchain4j.open-ai-official.streaming-chat-model.base-url=" + AZURE_ENDPOINT,
+                            "langchain4j.open-ai-official.streaming-chat-model.base-url=" + ENDPOINT,
                             "langchain4j.open-ai-official.streaming-chat-model.api-key=" + API_KEY,
-                            "langchain4j.open-ai-official.streaming-chat-model.is-microsoft-foundry=true",
-                            "langchain4j.open-ai-official.streaming-chat-model.microsoft-foundry-deployment-name=" + DEPLOYMENT_NAME,
-                            "langchain4j.open-ai-official.streaming-chat-model.model-name=" + DEPLOYMENT_NAME,
-                            "langchain4j.open-ai-official.streaming-chat-model.max-completion-tokens=20"
+                            "langchain4j.open-ai-official.streaming-chat-model.model-name=" + MODEL_NAME,
+                            "langchain4j.open-ai-official.streaming-chat-model.max-completion-tokens=200"
                     )
                     .run(context -> {
 
@@ -257,7 +252,7 @@ class OpenAiOfficialAutoConfigurationIT {
                 .withBean(OpenAiOfficialChatModel.class, () -> customChatModel)
                 .withPropertyValues(
                         "langchain4j.open-ai-official.chat-model.api-key=test-key",
-                        "langchain4j.open-ai-official.chat-model.model-name=gpt-4o-mini"
+                        "langchain4j.open-ai-official.chat-model.model-name=gpt-5-mini"
                 )
                 .run(context -> {
                     assertThat(context).hasSingleBean(OpenAiOfficialChatModel.class);
@@ -272,7 +267,7 @@ class OpenAiOfficialAutoConfigurationIT {
                 .withBean(OpenAiOfficialStreamingChatModel.class, () -> customModel)
                 .withPropertyValues(
                         "langchain4j.open-ai-official.streaming-chat-model.api-key=test-key",
-                        "langchain4j.open-ai-official.streaming-chat-model.model-name=gpt-4o-mini"
+                        "langchain4j.open-ai-official.streaming-chat-model.model-name=gpt-5-mini"
                 )
                 .run(context -> {
                     assertThat(context).hasSingleBean(OpenAiOfficialStreamingChatModel.class);
@@ -302,7 +297,7 @@ class OpenAiOfficialAutoConfigurationIT {
                 .withBean(OpenAiOfficialImageModel.class, () -> customModel)
                 .withPropertyValues(
                         "langchain4j.open-ai-official.image-model.api-key=test-key",
-                        "langchain4j.open-ai-official.image-model.model-name=dall-e-3"
+                        "langchain4j.open-ai-official.image-model.model-name=gpt-image-1"
                 )
                 .run(context -> {
                     assertThat(context).hasSingleBean(OpenAiOfficialImageModel.class);

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,8 @@
         <module>langchain4j-ollama-spring-boot4-starter</module>
         <module>langchain4j-open-ai-spring-boot-starter</module>
         <module>langchain4j-open-ai-spring-boot4-starter</module>
+        <module>langchain4j-open-ai-official-spring-boot-starter</module>
+        <module>langchain4j-open-ai-official-spring-boot4-starter</module>
         <module>langchain4j-azure-ai-search-spring-boot-starter</module>
         <module>langchain4j-azure-ai-search-spring-boot4-starter</module>
         <module>langchain4j-azure-open-ai-spring-boot-starter</module>


### PR DESCRIPTION
## Summary

Adds the missing Spring Boot auto-configuration starters for the `langchain4j-open-ai-official` module, which uses the [official OpenAI Java SDK](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-open-ai-official).

## New modules

- **`langchain4j-open-ai-official-spring-boot-starter`** (Spring Boot 3.x)
- **`langchain4j-open-ai-official-spring-boot4-starter`** (Spring Boot 4.x)

## Auto-configured beans

| Bean | Condition |
|------|-----------|
| `OpenAiOfficialChatModel` | `langchain4j.open-ai-official.chat-model.api-key` |
| `OpenAiOfficialStreamingChatModel` | `langchain4j.open-ai-official.streaming-chat-model.api-key` |
| `OpenAiOfficialEmbeddingModel` | `langchain4j.open-ai-official.embedding-model.api-key` |
| `OpenAiOfficialImageModel` | `langchain4j.open-ai-official.image-model.api-key` |

## Features

- Config prefix: `langchain4j.open-ai-official`
- Supports both **OpenAI** and **Azure OpenAI** (Microsoft Foundry) via `is-microsoft-foundry` and `microsoft-foundry-deployment-name` properties
- `ChatModelListener` support with ordering
- All beans have `@ConditionalOnMissingBean` to allow user overrides
- No HTTP client layer needed — uses the official OpenAI SDK's built-in client

## Test coverage

- Chat model, streaming chat model, listeners (OpenAI + Azure paths)
- No bean created when api-key is missing
- `@ConditionalOnMissingBean` for all 4 model types
- 11 tests per module (5 always-run + 3 OpenAI + 3 Azure)