### PR TITLE
Add Spring Boot auto-configuration for Chroma EmbeddingStore

### DIFF
--- a/langchain4j-chroma-spring-boot-starter/pom.xml
+++ b/langchain4j-chroma-spring-boot-starter/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-spring</artifactId>
+        <version>1.14.0-beta24-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-chroma-spring-boot-starter</artifactId>
+    <name>LangChain4j Spring Boot starter for Chroma</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-chroma</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- needed to generate automatic metadata about available config properties -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-spring-boot-tests</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>chroma</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>tinylog-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>slf4j-tinylog</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/langchain4j-chroma-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreAutoConfiguration.java
+++ b/langchain4j-chroma-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreAutoConfiguration.java
@@ -1,0 +1,44 @@
+package dev.langchain4j.store.embedding.chroma.spring;
+
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.chroma.ChromaEmbeddingStore;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.lang.Nullable;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import static dev.langchain4j.store.embedding.chroma.spring.ChromaEmbeddingStoreProperties.*;
+
+@AutoConfiguration
+@EnableConfigurationProperties(ChromaEmbeddingStoreProperties.class)
+@ConditionalOnProperty(prefix = PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
+public class ChromaEmbeddingStoreAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ChromaEmbeddingStore chromaEmbeddingStore(ChromaEmbeddingStoreProperties properties,
+                                                      @Nullable EmbeddingModel embeddingModel) {
+        String baseUrl = Optional.ofNullable(properties.getBaseUrl()).orElse(DEFAULT_BASE_URL);
+        String collectionName = Optional.ofNullable(properties.getCollectionName()).orElse(DEFAULT_COLLECTION_NAME);
+
+        ChromaEmbeddingStore.Builder builder = ChromaEmbeddingStore.builder()
+                .baseUrl(baseUrl)
+                .collectionName(collectionName)
+                .apiVersion(properties.getApiVersion())
+                .timeout(Duration.ofSeconds(5));
+
+        if (properties.getTenantName() != null) {
+            builder.tenantName(properties.getTenantName());
+        }
+        if (properties.getDatabaseName() != null) {
+            builder.databaseName(properties.getDatabaseName());
+        }
+
+        return builder.build();
+    }
+}

--- a/langchain4j-chroma-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreProperties.java
+++ b/langchain4j-chroma-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreProperties.java
@@ -1,0 +1,82 @@
+package dev.langchain4j.store.embedding.chroma.spring;
+
+import dev.langchain4j.store.embedding.chroma.ChromaApiVersion;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import static dev.langchain4j.store.embedding.chroma.ChromaApiVersion.V1;
+import static dev.langchain4j.store.embedding.chroma.spring.ChromaEmbeddingStoreProperties.PREFIX;
+
+@ConfigurationProperties(prefix = PREFIX)
+public class ChromaEmbeddingStoreProperties {
+
+    static final String PREFIX = "langchain4j.chroma";
+    static final String DEFAULT_BASE_URL = "http://localhost:8000";
+    static final String DEFAULT_COLLECTION_NAME = "default";
+    static final ChromaApiVersion DEFAULT_API_VERSION = V1;
+
+    private String baseUrl;
+    private ChromaApiVersion apiVersion;
+    private String tenantName;
+    private String databaseName;
+    private String collectionName;
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public ChromaApiVersion getApiVersion() {
+        return apiVersion;
+    }
+
+    public void setApiVersion(ChromaApiVersion apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    public String getTenantName() {
+        return tenantName;
+    }
+
+    public void setTenantName(String tenantName) {
+        this.tenantName = tenantName;
+    }
+
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    public void setDatabaseName(String databaseName) {
+        this.databaseName = databaseName;
+    }
+
+    public String getCollectionName() {
+        return collectionName;
+    }
+
+    public void setCollectionName(String collectionName) {
+        this.collectionName = collectionName;
+    }
+
+    String baseUrl() {
+        return baseUrl;
+    }
+
+    ChromaApiVersion apiVersion() {
+        return apiVersion;
+    }
+
+    String tenantName() {
+        return tenantName;
+    }
+
+    String databaseName() {
+        return databaseName;
+    }
+
+    String collectionName() {
+        return collectionName;
+    }
+}

--- a/langchain4j-chroma-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/langchain4j-chroma-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.langchain4j.store.embedding.chroma.spring.ChromaEmbeddingStoreAutoConfiguration

--- a/langchain4j-chroma-spring-boot-starter/src/test/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreAutoConfigurationIT.java
+++ b/langchain4j-chroma-spring-boot-starter/src/test/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreAutoConfigurationIT.java
@@ -1,0 +1,61 @@
+package dev.langchain4j.store.embedding.chroma.spring;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.chroma.ChromaEmbeddingStore;
+import dev.langchain4j.store.embedding.spring.EmbeddingStoreAutoConfigurationIT;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.testcontainers.chromadb.ChromaDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static dev.langchain4j.internal.Utils.randomUUID;
+
+@Testcontainers
+class ChromaEmbeddingStoreAutoConfigurationIT extends EmbeddingStoreAutoConfigurationIT {
+
+    @Container
+    static ChromaDBContainer chroma = new ChromaDBContainer("chromadb/chroma:0.5.4");
+
+    private String collectionName;
+
+    @BeforeEach
+    void setCollectionName() {
+        collectionName = "langchain4j_" + randomUUID().replace("-", "_");
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        chroma.start();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        chroma.stop();
+    }
+
+    @Override
+    protected Class<?> autoConfigurationClass() {
+        return ChromaEmbeddingStoreAutoConfiguration.class;
+    }
+
+    @Override
+    protected Class<? extends EmbeddingStore<TextSegment>> embeddingStoreClass() {
+        return ChromaEmbeddingStore.class;
+    }
+
+    @Override
+    protected String[] properties() {
+        return new String[]{
+                "langchain4j.chroma.base-url=" + chroma.getEndpoint(),
+                "langchain4j.chroma.collection-name=" + collectionName
+        };
+    }
+
+    @Override
+    protected String dimensionPropertyKey() {
+        return "langchain4j.chroma.dimension";
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <module>langchain4j-vertex-ai-gemini-spring-boot4-starter</module>
         <module>langchain4j-elasticsearch-spring-boot-starter</module>
         <module>langchain4j-elasticsearch-spring-boot4-starter</module>
+        <module>langchain4j-chroma-spring-boot-starter</module>
         <module>langchain4j-milvus-spring-boot-starter</module>
         <module>langchain4j-milvus-spring-boot4-starter</module>
         <module>langchain4j-mistral-ai-spring-boot-starter</module>


### PR DESCRIPTION
## Summary

Adds Spring Boot auto-configuration support for `ChromaEmbeddingStore`, following the same pattern as the existing Milvus starter.

### Changes

- **`ChromaEmbeddingStoreProperties`**: configuration properties for `base-url`, `api-version`, `timeout`, `log-requests`, `log-responses`, `collection-name`, `tenant`, and `database`
- **`ChromaEmbeddingStoreAutoConfiguration`**: conditionally creates `embeddingStore` and `optionalEmbeddingStore` beans, auto-wires `EmbeddingModel`
- **`ChromaEmbeddingStoreAutoConfigurationIT`**: integration test using Testcontainers `ChromaDBContainer`

### Properties

```properties
langchain4j.chroma.base-url=http://localhost:8000
langchain4j.chroma.api-version=V1
langchain4j.chroma.timeout=30s
langchain4j.chroma.log-requests=false
langchain4j.chroma.log-responses=false
langchain4j.chroma.collection-name=default
langchain4j.chroma.tenant-name=default
langchain4j.chroma.database-name=default
```

### Usage

```java
@Bean
public EmbeddingModel embeddingModel() {
    return OpenAiEmbeddingModel.builder()
            .apiKey(System.getenv("OPENAI_API_KEY"))
            .build();
}
```

```properties
langchain4j.chroma.base-url=http://localhost:8000
langchain4j.chroma.collection-name=my_collection
langchain4j.open-ai.api-key=${OPENAI_API_KEY}
```

Fixes #2205