### PR TITLE
Add Spring Boot auto-configuration for PgVector EmbeddingStore

### DIFF
--- a/langchain4j-pgvector-spring-boot-starter/pom.xml
+++ b/langchain4j-pgvector-spring-boot-starter/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-spring</artifactId>
+        <version>1.14.0-beta24-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-pgvector-spring-boot-starter</artifactId>
+    <name>LangChain4j Spring Boot starter for PgVector</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-pgvector</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- needed to generate automatic metadata about available config properties -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-spring-boot-tests</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>tinylog-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>slf4j-tinylog</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/langchain4j-pgvector-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/pgvector/spring/PgVectorEmbeddingStoreAutoConfiguration.java
+++ b/langchain4j-pgvector-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/pgvector/spring/PgVectorEmbeddingStoreAutoConfiguration.java
@@ -1,0 +1,62 @@
+package dev.langchain4j.store.embedding.pgvector.spring;
+
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.lang.Nullable;
+
+import java.util.Optional;
+
+import static dev.langchain4j.store.embedding.pgvector.spring.PgVectorEmbeddingStoreProperties.*;
+
+@AutoConfiguration
+@EnableConfigurationProperties(PgVectorEmbeddingStoreProperties.class)
+@ConditionalOnProperty(prefix = PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
+public class PgVectorEmbeddingStoreAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public PgVectorEmbeddingStore pgvectorEmbeddingStore(PgVectorEmbeddingStoreProperties properties,
+                                                         @Nullable EmbeddingModel embeddingModel) {
+        String host = Optional.ofNullable(properties.getHost()).orElse(DEFAULT_HOST);
+        int port = Optional.ofNullable(properties.getPort()).orElse(DEFAULT_PORT);
+        String database = Optional.ofNullable(properties.getDatabase()).orElse(DEFAULT_DATABASE);
+        String table = Optional.ofNullable(properties.getTable()).orElse(DEFAULT_TABLE);
+        Integer dimension = properties.getDimension();
+        if (dimension == null && embeddingModel != null) {
+            dimension = embeddingModel.dimension();
+        }
+
+        // get password from env variable if not set
+        String password = Optional.ofNullable(properties.getPassword()).orElse(System.getenv("PGVECTOR_PASSWORD"));
+
+        PgVectorEmbeddingStore.PgVectorEmbeddingStoreBuilder builder = PgVectorEmbeddingStore.builder()
+                .host(host)
+                .port(port)
+                .database(database)
+                .table(table)
+                .dimension(dimension)
+                .useIndex(properties.getUseIndex())
+                .indexListSize(properties.getIndexListSize())
+                .createTable(properties.getCreateTable())
+                .dropTableFirst(properties.getDropTableFirst())
+                .skipCreateVectorExtension(properties.getSkipCreateVectorExtension())
+                .searchMode(properties.getSearchMode())
+                .textSearchConfig(properties.getTextSearchConfig())
+                .rrfK(properties.getRrfK());
+
+        String user = properties.getUser();
+        if (user != null) {
+            builder.user(user);
+        }
+        if (password != null) {
+            builder.password(password);
+        }
+
+        return builder.build();
+    }
+}

--- a/langchain4j-pgvector-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/pgvector/spring/PgVectorEmbeddingStoreProperties.java
+++ b/langchain4j-pgvector-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/pgvector/spring/PgVectorEmbeddingStoreProperties.java
@@ -1,0 +1,212 @@
+package dev.langchain4j.store.embedding.pgvector.spring;
+
+import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import static dev.langchain4j.store.embedding.pgvector.spring.PgVectorEmbeddingStoreProperties.PREFIX;
+
+@ConfigurationProperties(prefix = PREFIX)
+public class PgVectorEmbeddingStoreProperties {
+
+    static final String PREFIX = "langchain4j.pgvector";
+    static final String DEFAULT_HOST = "localhost";
+    static final int DEFAULT_PORT = 5432;
+    static final String DEFAULT_TABLE = "langchain4j_embedding";
+    static final String DEFAULT_DATABASE = "postgres";
+
+    private String host;
+    private Integer port;
+    private String user;
+    private String password;
+    private String database;
+    private String table;
+    private Integer dimension;
+    private Boolean useIndex;
+    private Integer indexListSize;
+    private Boolean createTable;
+    private Boolean dropTableFirst;
+    private Boolean skipCreateVectorExtension;
+    private PgVectorEmbeddingStore.SearchMode searchMode;
+    private String textSearchConfig;
+    private Integer rrfK;
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public void setDatabase(String database) {
+        this.database = database;
+    }
+
+    public String getTable() {
+        return table;
+    }
+
+    public void setTable(String table) {
+        this.table = table;
+    }
+
+    public Integer getDimension() {
+        return dimension;
+    }
+
+    public void setDimension(Integer dimension) {
+        this.dimension = dimension;
+    }
+
+    public Boolean getUseIndex() {
+        return useIndex;
+    }
+
+    public void setUseIndex(Boolean useIndex) {
+        this.useIndex = useIndex;
+    }
+
+    public Integer getIndexListSize() {
+        return indexListSize;
+    }
+
+    public void setIndexListSize(Integer indexListSize) {
+        this.indexListSize = indexListSize;
+    }
+
+    public Boolean getCreateTable() {
+        return createTable;
+    }
+
+    public void setCreateTable(Boolean createTable) {
+        this.createTable = createTable;
+    }
+
+    public Boolean getDropTableFirst() {
+        return dropTableFirst;
+    }
+
+    public void setDropTableFirst(Boolean dropTableFirst) {
+        this.dropTableFirst = dropTableFirst;
+    }
+
+    public Boolean getSkipCreateVectorExtension() {
+        return skipCreateVectorExtension;
+    }
+
+    public void setSkipCreateVectorExtension(Boolean skipCreateVectorExtension) {
+        this.skipCreateVectorExtension = skipCreateVectorExtension;
+    }
+
+    public PgVectorEmbeddingStore.SearchMode getSearchMode() {
+        return searchMode;
+    }
+
+    public void setSearchMode(PgVectorEmbeddingStore.SearchMode searchMode) {
+        this.searchMode = searchMode;
+    }
+
+    public String getTextSearchConfig() {
+        return textSearchConfig;
+    }
+
+    public void setTextSearchConfig(String textSearchConfig) {
+        this.textSearchConfig = textSearchConfig;
+    }
+
+    public Integer getRrfK() {
+        return rrfK;
+    }
+
+    public void setRrfK(Integer rrfK) {
+        this.rrfK = rrfK;
+    }
+
+    String host() {
+        return host;
+    }
+
+    Integer port() {
+        return port;
+    }
+
+    String user() {
+        return user;
+    }
+
+    String password() {
+        return password;
+    }
+
+    String database() {
+        return database;
+    }
+
+    String table() {
+        return table;
+    }
+
+    Integer dimension() {
+        return dimension;
+    }
+
+    Boolean useIndex() {
+        return useIndex;
+    }
+
+    Integer indexListSize() {
+        return indexListSize;
+    }
+
+    Boolean createTable() {
+        return createTable;
+    }
+
+    Boolean dropTableFirst() {
+        return dropTableFirst;
+    }
+
+    Boolean skipCreateVectorExtension() {
+        return skipCreateVectorExtension;
+    }
+
+    PgVectorEmbeddingStore.SearchMode searchMode() {
+        return searchMode;
+    }
+
+    String textSearchConfig() {
+        return textSearchConfig;
+    }
+
+    Integer rrfK() {
+        return rrfK;
+    }
+}

--- a/langchain4j-pgvector-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/langchain4j-pgvector-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.langchain4j.store.embedding.pgvector.spring.PgVectorEmbeddingStoreAutoConfiguration

--- a/langchain4j-pgvector-spring-boot-starter/src/test/java/dev/langchain4j/store/embedding/pgvector/spring/PgVectorEmbeddingStoreAutoConfigurationIT.java
+++ b/langchain4j-pgvector-spring-boot-starter/src/test/java/dev/langchain4j/store/embedding/pgvector/spring/PgVectorEmbeddingStoreAutoConfigurationIT.java
@@ -1,0 +1,65 @@
+package dev.langchain4j.store.embedding.pgvector.spring;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
+import dev.langchain4j.store.embedding.spring.EmbeddingStoreAutoConfigurationIT;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static dev.langchain4j.internal.Utils.randomUUID;
+
+@Testcontainers
+class PgVectorEmbeddingStoreAutoConfigurationIT extends EmbeddingStoreAutoConfigurationIT {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    private String tableName;
+
+    @BeforeEach
+    void setTableName() {
+        tableName = "langchain4j_" + randomUUID().replace("-", "_");
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        postgres.start();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        postgres.stop();
+    }
+
+    @Override
+    protected Class<?> autoConfigurationClass() {
+        return PgVectorEmbeddingStoreAutoConfiguration.class;
+    }
+
+    @Override
+    protected Class<? extends EmbeddingStore<TextSegment>> embeddingStoreClass() {
+        return PgVectorEmbeddingStore.class;
+    }
+
+    @Override
+    protected String[] properties() {
+        return new String[]{
+                "langchain4j.pgvector.host=" + postgres.getHost(),
+                "langchain4j.pgvector.port=" + postgres.getMappedPort(5432),
+                "langchain4j.pgvector.user=" + postgres.getUsername(),
+                "langchain4j.pgvector.password=" + postgres.getPassword(),
+                "langchain4j.pgvector.database=" + postgres.getDatabaseName(),
+                "langchain4j.pgvector.table=" + tableName
+        };
+    }
+
+    @Override
+    protected String dimensionPropertyKey() {
+        return "langchain4j.pgvector.dimension";
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <module>langchain4j-vertex-ai-gemini-spring-boot4-starter</module>
         <module>langchain4j-elasticsearch-spring-boot-starter</module>
         <module>langchain4j-elasticsearch-spring-boot4-starter</module>
+        <module>langchain4j-pgvector-spring-boot-starter</module>
         <module>langchain4j-milvus-spring-boot-starter</module>
         <module>langchain4j-milvus-spring-boot4-starter</module>
         <module>langchain4j-mistral-ai-spring-boot-starter</module>


### PR DESCRIPTION
## Summary

Adds Spring Boot auto-configuration support for `PgVectorEmbeddingStore`, following the same pattern as the existing Milvus and Chroma starters.

### Changes

- **`PgVectorEmbeddingStoreProperties`**: exposes all configurable properties (host, port, user, password, database, table, dimension, useIndex, indexListSize, createTable, dropTableFirst, skipCreateVectorExtension, searchMode, textSearchConfig, rrfK)
- **`PgVectorEmbeddingStoreAutoConfiguration`**: conditionally creates `pgvectorEmbeddingStore` bean, auto-wires `EmbeddingModel`
- **Integration test** with Testcontainers `PostgreSQLContainer`

### Properties

| Property | Default |
|----------|---------|
| `langchain4j.pgvector.host` | `localhost` |
| `langchain4j.pgvector.port` | `5432` |
| `langchain4j.pgvector.user` | _(none)_ |
| `langchain4j.pgvector.password` | _(env: `PGVECTOR_PASSWORD`)_ |
| `langchain4j.pgvector.database` | `postgres` |
| `langchain4j.pgvector.table` | `langchain4j_embedding` |
| `langchain4j.pgvector.dimension` | _(from EmbeddingModel)_ |

### Example usage

```yaml
langchain4j:
  pgvector:
    host: localhost
    port: 5432
    user: postgres
    password: ${PGVECTOR_PASSWORD}
    database: postgres
    dimension: 384
```

Fixes langchain4j/langchain4j#2102