### PR TITLE
Add Qdrant Spring Boot starter (Boot 3 and Boot 4)

### DIFF
--- a/langchain4j-qdrant-spring-boot-starter/pom.xml
+++ b/langchain4j-qdrant-spring-boot-starter/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-spring</artifactId>
+        <version>1.14.0-beta24-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-qdrant-spring-boot-starter</artifactId>
+    <name>LangChain4j Spring Boot starter for Qdrant</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-qdrant</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- needed to generate automatic metadata about available config properties -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-spring-boot-tests</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>qdrant</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>tinylog-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>slf4j-tinylog</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/langchain4j-qdrant-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/qdrant/spring/QdrantEmbeddingStoreAutoConfiguration.java
+++ b/langchain4j-qdrant-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/qdrant/spring/QdrantEmbeddingStoreAutoConfiguration.java
@@ -1,0 +1,46 @@
+package dev.langchain4j.store.embedding.qdrant.spring;
+
+import dev.langchain4j.store.embedding.qdrant.QdrantEmbeddingStore;
+import io.qdrant.client.QdrantClient;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.lang.Nullable;
+
+import java.util.Optional;
+
+import static dev.langchain4j.store.embedding.qdrant.spring.QdrantEmbeddingStoreProperties.*;
+
+@AutoConfiguration
+@EnableConfigurationProperties(QdrantEmbeddingStoreProperties.class)
+@ConditionalOnProperty(prefix = PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
+public class QdrantEmbeddingStoreAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public QdrantEmbeddingStore qdrantEmbeddingStore(QdrantEmbeddingStoreProperties properties,
+                                                     @Nullable QdrantClient qdrantClient) {
+        QdrantEmbeddingStore.Builder builder = QdrantEmbeddingStore.builder()
+                .collectionName(properties.getCollectionName());
+
+        if (qdrantClient != null) {
+            return builder.client(qdrantClient).build();
+        }
+
+        String host = Optional.ofNullable(properties.getHost()).orElse(DEFAULT_HOST);
+        int port = Optional.ofNullable(properties.getPort()).orElse(DEFAULT_PORT);
+        boolean useTls = Optional.ofNullable(properties.getUseTls()).orElse(DEFAULT_USE_TLS);
+        String payloadTextKey = Optional.ofNullable(properties.getPayloadTextKey()).orElse(DEFAULT_PAYLOAD_TEXT_KEY);
+        String apiKey = Optional.ofNullable(properties.getApiKey()).orElse(System.getenv("QDRANT_API_KEY"));
+
+        return builder
+                .host(host)
+                .port(port)
+                .useTls(useTls)
+                .payloadTextKey(payloadTextKey)
+                .apiKey(apiKey)
+                .build();
+    }
+}

--- a/langchain4j-qdrant-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/qdrant/spring/QdrantEmbeddingStoreProperties.java
+++ b/langchain4j-qdrant-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/qdrant/spring/QdrantEmbeddingStoreProperties.java
@@ -1,0 +1,83 @@
+package dev.langchain4j.store.embedding.qdrant.spring;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = QdrantEmbeddingStoreProperties.PREFIX)
+public class QdrantEmbeddingStoreProperties {
+
+    static final String PREFIX = "langchain4j.qdrant";
+    static final String DEFAULT_HOST = "localhost";
+    static final int DEFAULT_PORT = 6334;
+    static final boolean DEFAULT_USE_TLS = false;
+    static final String DEFAULT_PAYLOAD_TEXT_KEY = "text_segment";
+
+    private String host;
+    private Integer port;
+    private Boolean useTls;
+    private String collectionName;
+    private String payloadTextKey;
+    private String apiKey;
+    /** 
+     * The dimension of the vectors stored in the Qdrant collection.
+     * Note: in Qdrant, dimension is set at collection creation time, not on the
+     * embedding store itself. This property is not used by the auto-configuration
+     * but is declared here for consistency with other LangChain4j starters.
+    */
+    private Integer dimension;
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+
+    public Boolean getUseTls() {
+        return useTls;
+    }
+
+    public void setUseTls(Boolean useTls) {
+        this.useTls = useTls;
+    }
+
+    public String getCollectionName() {
+        return collectionName;
+    }
+
+    public void setCollectionName(String collectionName) {
+        this.collectionName = collectionName;
+    }
+
+    public String getPayloadTextKey() {
+        return payloadTextKey;
+    }
+
+    public void setPayloadTextKey(String payloadTextKey) {
+        this.payloadTextKey = payloadTextKey;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+    
+    public Integer getDimension() { 
+        return dimension; 
+    }
+
+    public void setDimension(Integer dimension) { 
+        this.dimension = dimension; 
+    } 
+}

--- a/langchain4j-qdrant-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/langchain4j-qdrant-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.langchain4j.store.embedding.qdrant.spring.QdrantEmbeddingStoreAutoConfiguration

--- a/langchain4j-qdrant-spring-boot-starter/src/test/java/dev/langchain4j/store/embedding/qdrant/spring/QdrantEmbeddingStoreAutoConfigurationIT.java
+++ b/langchain4j-qdrant-spring-boot-starter/src/test/java/dev/langchain4j/store/embedding/qdrant/spring/QdrantEmbeddingStoreAutoConfigurationIT.java
@@ -1,0 +1,85 @@
+package dev.langchain4j.store.embedding.qdrant.spring;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.qdrant.QdrantEmbeddingStore;
+import dev.langchain4j.store.embedding.spring.EmbeddingStoreAutoConfigurationIT;
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections.Distance;
+import io.qdrant.client.grpc.Collections.VectorParams;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.testcontainers.qdrant.QdrantContainer;
+
+import java.util.concurrent.ExecutionException;
+
+import static dev.langchain4j.internal.Utils.randomUUID;
+
+class QdrantEmbeddingStoreAutoConfigurationIT extends EmbeddingStoreAutoConfigurationIT {
+
+    static QdrantContainer qdrant = new QdrantContainer("qdrant/qdrant:latest");
+
+    static QdrantClient adminClient;
+
+    String collectionName;
+
+    @BeforeAll
+    static void beforeAll() {
+        qdrant.start();
+        adminClient = new QdrantClient(
+                QdrantGrpcClient.newBuilder(qdrant.getHost(), qdrant.getGrpcPort(), false).build());
+    }
+
+    @AfterAll
+    static void afterAll() {
+        adminClient.close();
+        qdrant.stop();
+    }
+
+    @BeforeEach
+    void createCollection() throws ExecutionException, InterruptedException {
+        collectionName = "langchain4j_" + randomUUID().replace("-", "_");
+        int dimension = new AllMiniLmL6V2QuantizedEmbeddingModel().dimension();
+        adminClient.createCollectionAsync(
+                collectionName,
+                VectorParams.newBuilder()
+                        .setDistance(Distance.Cosine)
+                        .setSize(dimension)
+                        .build()
+        ).get();
+    }
+    
+    
+    @AfterEach
+    void deleteCollection() throws ExecutionException, InterruptedException {
+        adminClient.deleteCollectionAsync(collectionName).get();
+    }
+
+    @Override
+    protected Class<?> autoConfigurationClass() {
+        return QdrantEmbeddingStoreAutoConfiguration.class;
+    }
+
+    @Override
+    protected Class<? extends EmbeddingStore<TextSegment>> embeddingStoreClass() {
+        return QdrantEmbeddingStore.class;
+    }
+
+    @Override
+    protected String[] properties() {
+        return new String[]{
+                "langchain4j.qdrant.host=" + qdrant.getHost(),
+                "langchain4j.qdrant.port=" + qdrant.getGrpcPort(),
+                "langchain4j.qdrant.collectionName=" + collectionName
+        };
+    }
+    
+    @Override
+    protected String dimensionPropertyKey() {
+        return "langchain4j.qdrant.dimension";  // declared in properties, not used by auto-config
+    }
+}

--- a/langchain4j-qdrant-spring-boot4-starter/pom.xml
+++ b/langchain4j-qdrant-spring-boot4-starter/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-spring</artifactId>
+        <version>1.14.0-beta24-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-qdrant-spring-boot4-starter</artifactId>
+    <name>LangChain4j Spring Boot 4 starter for Qdrant</name>
+    <packaging>jar</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Override Spring Boot version from parent -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot4.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-qdrant</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- needed to generate automatic metadata about available config properties -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-spring-boot4-tests</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-qdrant</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>tinylog-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>slf4j-tinylog</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/langchain4j-qdrant-spring-boot4-starter/src/main/java/dev/langchain4j/store/embedding/qdrant/spring/QdrantEmbeddingStoreAutoConfiguration.java
+++ b/langchain4j-qdrant-spring-boot4-starter/src/main/java/dev/langchain4j/store/embedding/qdrant/spring/QdrantEmbeddingStoreAutoConfiguration.java
@@ -1,0 +1,48 @@
+package dev.langchain4j.store.embedding.qdrant.spring;
+
+import dev.langchain4j.store.embedding.qdrant.QdrantEmbeddingStore;
+import io.qdrant.client.QdrantClient;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.lang.Nullable;
+
+import java.util.Optional;
+
+import static dev.langchain4j.store.embedding.qdrant.spring.QdrantEmbeddingStoreProperties.*;
+
+@AutoConfiguration
+@EnableConfigurationProperties(QdrantEmbeddingStoreProperties.class)
+@ConditionalOnProperty(prefix = PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
+public class QdrantEmbeddingStoreAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public QdrantEmbeddingStore qdrantEmbeddingStore(QdrantEmbeddingStoreProperties properties,
+                                                     @Nullable QdrantClient qdrantClient) {
+
+        QdrantEmbeddingStore.Builder builder = QdrantEmbeddingStore.builder()
+                .collectionName(properties.getCollectionName());
+
+        if (qdrantClient != null) {
+            return builder.client(qdrantClient).build();
+        }
+
+        String host = Optional.ofNullable(properties.getHost()).orElse(DEFAULT_HOST);
+        int port = Optional.ofNullable(properties.getPort()).orElse(DEFAULT_PORT);
+        boolean useTls = Optional.ofNullable(properties.getUseTls()).orElse(DEFAULT_USE_TLS);
+        String payloadTextKey = Optional.ofNullable(properties.getPayloadTextKey()).orElse(DEFAULT_PAYLOAD_TEXT_KEY);
+        String apiKey = Optional.ofNullable(properties.getApiKey())
+                .orElse(System.getenv("QDRANT_API_KEY"));
+
+        return builder
+                .host(host)
+                .port(port)
+                .useTls(useTls)
+                .payloadTextKey(payloadTextKey)
+                .apiKey(apiKey)
+                .build();
+    }
+}

--- a/langchain4j-qdrant-spring-boot4-starter/src/main/java/dev/langchain4j/store/embedding/qdrant/spring/QdrantEmbeddingStoreProperties.java
+++ b/langchain4j-qdrant-spring-boot4-starter/src/main/java/dev/langchain4j/store/embedding/qdrant/spring/QdrantEmbeddingStoreProperties.java
@@ -1,0 +1,83 @@
+package dev.langchain4j.store.embedding.qdrant.spring;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = QdrantEmbeddingStoreProperties.PREFIX)
+public class QdrantEmbeddingStoreProperties {
+
+    static final String PREFIX = "langchain4j.qdrant";
+    static final String DEFAULT_HOST = "localhost";
+    static final int DEFAULT_PORT = 6334;
+    static final boolean DEFAULT_USE_TLS = false;
+    static final String DEFAULT_PAYLOAD_TEXT_KEY = "text_segment";
+
+    private String host;
+    private Integer port;
+    private Boolean useTls;
+    private String collectionName;
+    private String payloadTextKey;
+    private String apiKey;
+    /**
+     * The dimension of the vectors stored in the Qdrant collection.
+     * Note: in Qdrant, dimension is set at collection creation time, not on the
+     * embedding store itself. This property is not used by the auto-configuration
+     * but is declared here for consistency with other LangChain4j starters.
+    */
+    private Integer dimension;
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+
+    public Boolean getUseTls() {
+        return useTls;
+    }
+
+    public void setUseTls(Boolean useTls) {
+        this.useTls = useTls;
+    }
+
+    public String getCollectionName() {
+        return collectionName;
+    }
+
+    public void setCollectionName(String collectionName) {
+        this.collectionName = collectionName;
+    }
+
+    public String getPayloadTextKey() {
+        return payloadTextKey;
+    }
+
+    public void setPayloadTextKey(String payloadTextKey) {
+        this.payloadTextKey = payloadTextKey;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    public Integer getDimension() { 
+        return dimension; 
+    }
+
+    public void setDimension(Integer dimension) { 
+        this.dimension = dimension; 
+    } 
+}

--- a/langchain4j-qdrant-spring-boot4-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/langchain4j-qdrant-spring-boot4-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.langchain4j.store.embedding.qdrant.spring.QdrantEmbeddingStoreAutoConfiguration

--- a/langchain4j-qdrant-spring-boot4-starter/src/test/java/dev/langchain4j/store/embedding/qdrant/spring/QdrantEmbeddingStoreAutoConfigurationIT.java
+++ b/langchain4j-qdrant-spring-boot4-starter/src/test/java/dev/langchain4j/store/embedding/qdrant/spring/QdrantEmbeddingStoreAutoConfigurationIT.java
@@ -1,0 +1,85 @@
+package dev.langchain4j.store.embedding.qdrant.spring;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.qdrant.QdrantEmbeddingStore;
+import dev.langchain4j.store.embedding.spring.EmbeddingStoreAutoConfigurationIT;
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections.Distance;
+import io.qdrant.client.grpc.Collections.VectorParams;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.testcontainers.qdrant.QdrantContainer;
+
+import java.util.concurrent.ExecutionException;
+
+import static dev.langchain4j.internal.Utils.randomUUID;
+
+class QdrantEmbeddingStoreAutoConfigurationIT extends EmbeddingStoreAutoConfigurationIT {
+
+    static QdrantContainer qdrant = new QdrantContainer("qdrant/qdrant:latest");
+
+    static QdrantClient adminClient;
+
+    String collectionName;
+
+    @BeforeAll
+    static void beforeAll() {
+        qdrant.start();
+        adminClient = new QdrantClient(
+                QdrantGrpcClient.newBuilder(qdrant.getHost(), qdrant.getGrpcPort(), false).build());
+    }
+
+    @AfterAll
+    static void afterAll() {
+        adminClient.close();
+        qdrant.stop();
+    }
+
+    @BeforeEach
+    void createCollection() throws ExecutionException, InterruptedException {
+        collectionName = "langchain4j_" + randomUUID().replace("-", "_");
+        int dimension = new AllMiniLmL6V2QuantizedEmbeddingModel().dimension();
+        adminClient.createCollectionAsync(
+                collectionName,
+                VectorParams.newBuilder()
+                        .setDistance(Distance.Cosine)
+                        .setSize(dimension)
+                        .build()
+        ).get();
+    }
+
+    @AfterEach
+    void deleteCollection() throws ExecutionException, InterruptedException {
+        adminClient.deleteCollectionAsync(collectionName).get();
+    }
+
+    @Override
+    protected Class<?> autoConfigurationClass() {
+        return QdrantEmbeddingStoreAutoConfiguration.class;
+    }
+
+    @Override
+    protected Class<? extends EmbeddingStore<TextSegment>> embeddingStoreClass() {
+        return QdrantEmbeddingStore.class;
+    }
+
+    @Override
+    protected String[] properties() {
+        return new String[]{
+                "langchain4j.qdrant.host=" + qdrant.getHost(),
+                "langchain4j.qdrant.port=" + qdrant.getGrpcPort(),
+                "langchain4j.qdrant.collectionName=" + collectionName
+        };
+    }
+
+    @Override
+    protected String dimensionPropertyKey() {
+        return "langchain4j.qdrant.dimension";  // declared in properties, not used by auto-config
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,8 @@
         <module>langchain4j-elasticsearch-spring-boot4-starter</module>
         <module>langchain4j-milvus-spring-boot-starter</module>
         <module>langchain4j-milvus-spring-boot4-starter</module>
+        <module>langchain4j-qdrant-spring-boot-starter</module>
+        <module>langchain4j-qdrant-spring-boot4-starter</module>
         <module>langchain4j-mistral-ai-spring-boot-starter</module>
         <module>langchain4j-mistral-ai-spring-boot4-starter</module>
 


### PR DESCRIPTION
## Issue
Closes langchain4j/langchain4j#4925

## Change
Implements Spring Boot auto-configuration for `langchain4j-qdrant` embedding store,
following the established pattern of existing starters (Milvus, Elasticsearch).

- `QdrantEmbeddingStoreProperties` — configuration properties under `langchain4j.qdrant.*`
- `QdrantEmbeddingStoreAutoConfiguration` — creates a `QdrantEmbeddingStore` bean,
  supporting both an existing `QdrantClient` bean (if present) and explicit host/port
  properties as fallback
- Integration test using Testcontainers (`qdrant/qdrant:latest`)
- Both Spring Boot 3 and Spring Boot 4 variants included

## General checklist
- [X] There are no breaking changes
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)

## Checklist for adding new Spring Boot starter
- [X] I have added my new starter in the root `pom.xml`
- [X] I have added a `org.springframework.boot.autoconfigure.AutoConfiguration.imports` file in the `langchain4j-qdrant-spring-boot-starter/src/main/resources/META-INF/spring/` directory