### PR TITLE
Add Spring Boot auto-configuration for PgVector EmbeddingStore

### DIFF
--- a/langchain4j-pgvector-spring-boot-starter/pom.xml
+++ b/langchain4j-pgvector-spring-boot-starter/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-spring</artifactId>
+        <version>1.14.0-beta24-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-pgvector-spring-boot-starter</artifactId>
+    <name>LangChain4j Spring Boot starter for PgVector</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-pgvector</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- needed to generate automatic metadata about available config properties -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-spring-boot-tests</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>tinylog-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>slf4j-tinylog</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/langchain4j-pgvector-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/pgvector/spring/PgVectorEmbeddingStoreAutoConfiguration.java
+++ b/langchain4j-pgvector-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/pgvector/spring/PgVectorEmbeddingStoreAutoConfiguration.java
@@ -1,0 +1,117 @@
+package dev.langchain4j.store.embedding.pgvector.spring;
+
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy;
+import org.springframework.lang.Nullable;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.util.Optional;
+
+import static dev.langchain4j.store.embedding.pgvector.spring.PgVectorEmbeddingStoreProperties.PREFIX;
+
+@AutoConfiguration
+@EnableConfigurationProperties(PgVectorEmbeddingStoreProperties.class)
+@ConditionalOnProperty(prefix = PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
+public class PgVectorEmbeddingStoreAutoConfiguration {
+
+    private static final Logger log = LoggerFactory.getLogger(PgVectorEmbeddingStoreAutoConfiguration.class);
+
+    @Bean
+    @ConditionalOnMissingBean
+    public PgVectorEmbeddingStore pgVectorEmbeddingStore(PgVectorEmbeddingStoreProperties properties,
+                                                         ObjectProvider<DataSource> dataSources,
+                                                         ApplicationContext applicationContext,
+                                                         @Nullable EmbeddingModel embeddingModel) {
+        Integer dimension = Optional.ofNullable(properties.getDimension())
+                .orElseGet(() -> embeddingModel == null ? null : embeddingModel.dimension());
+
+        // If explicit host is specified, use the host/port/user/password builder
+        if (properties.getHost() != null) {
+            return PgVectorEmbeddingStore.builder()
+                    .host(properties.getHost())
+                    .port(properties.getPort())
+                    .user(properties.getUser())
+                    .password(properties.getPassword())
+                    .database(properties.getDatabase())
+                    .table(properties.getTable())
+                    .dimension(dimension)
+                    .useIndex(properties.getUseIndex())
+                    .indexListSize(properties.getIndexListSize())
+                    .createTable(properties.getCreateTable())
+                    .dropTableFirst(properties.getDropTableFirst())
+                    .skipCreateVectorExtension(properties.getSkipCreateVectorExtension())
+                    .searchMode(properties.getSearchMode())
+                    .textSearchConfig(properties.getTextSearchConfig())
+                    .rrfK(properties.getRrfK())
+                    .build();
+        }
+
+        // Otherwise, use an existing DataSource from the Spring context
+        DataSource dataSource = resolveDataSource(properties, dataSources, applicationContext);
+
+        // Wrap for @Transactional support (Issue #2614)
+        DataSource transactionalDataSource = new TransactionAwareDataSourceProxy(dataSource);
+
+        return PgVectorEmbeddingStore.datasourceBuilder()
+                .datasource(transactionalDataSource)
+                .table(properties.getTable())
+                .dimension(dimension)
+                .useIndex(properties.getUseIndex())
+                .indexListSize(properties.getIndexListSize())
+                .createTable(properties.getCreateTable())
+                .dropTableFirst(properties.getDropTableFirst())
+                .skipCreateVectorExtension(properties.getSkipCreateVectorExtension())
+                .searchMode(properties.getSearchMode())
+                .textSearchConfig(properties.getTextSearchConfig())
+                .rrfK(properties.getRrfK())
+                .build();
+    }
+
+    private DataSource resolveDataSource(PgVectorEmbeddingStoreProperties properties,
+                                         ObjectProvider<DataSource> dataSources,
+                                         ApplicationContext applicationContext) {
+        String beanName = properties.getDataSourceBeanName();
+
+        // If a specific DataSource bean name is configured, use that
+        if (beanName != null && !beanName.isEmpty()) {
+            DataSource dataSource = applicationContext.getBean(beanName, DataSource.class);
+            log.info("Using configured DataSource bean: {}", beanName);
+            return dataSource;
+        }
+
+        // Otherwise, find the first PostgreSQL DataSource
+        DataSource dataSource = dataSources.stream()
+                .filter(this::isPostgresqlDataSource)
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException(
+                        "No suitable PostgreSQL DataSource found in the application context. "
+                                + "Please configure a PostgreSQL DataSource or specify explicit connection properties "
+                                + "via 'langchain4j.pgvector.host', 'langchain4j.pgvector.port', etc."));
+        log.info("Using auto-detected PostgreSQL DataSource: {}", dataSource.getClass().getSimpleName());
+        return dataSource;
+    }
+
+    private boolean isPostgresqlDataSource(DataSource dataSource) {
+        try (Connection connection = dataSource.getConnection()) {
+            DatabaseMetaData metaData = connection.getMetaData();
+            String url = metaData.getURL();
+            return url != null && url.toLowerCase().startsWith("jdbc:postgresql");
+        } catch (SQLException e) {
+            log.warn("Could not determine DataSource type during PgVector auto-configuration", e);
+            return false;
+        }
+    }
+}

--- a/langchain4j-pgvector-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/pgvector/spring/PgVectorEmbeddingStoreProperties.java
+++ b/langchain4j-pgvector-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/pgvector/spring/PgVectorEmbeddingStoreProperties.java
@@ -1,0 +1,155 @@
+package dev.langchain4j.store.embedding.pgvector.spring;
+
+import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = PgVectorEmbeddingStoreProperties.PREFIX)
+public class PgVectorEmbeddingStoreProperties {
+
+    static final String PREFIX = "langchain4j.pgvector";
+
+    private String host;
+    private Integer port;
+    private String user;
+    private String password;
+    private String database;
+    private String table;
+    private Integer dimension;
+    private Boolean useIndex;
+    private Integer indexListSize;
+    private Boolean createTable;
+    private Boolean dropTableFirst;
+    private Boolean skipCreateVectorExtension;
+    private PgVectorEmbeddingStore.SearchMode searchMode;
+    private String textSearchConfig;
+    private Integer rrfK;
+    private String dataSourceBeanName;
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public void setDatabase(String database) {
+        this.database = database;
+    }
+
+    public String getTable() {
+        return table;
+    }
+
+    public void setTable(String table) {
+        this.table = table;
+    }
+
+    public Integer getDimension() {
+        return dimension;
+    }
+
+    public void setDimension(Integer dimension) {
+        this.dimension = dimension;
+    }
+
+    public Boolean getUseIndex() {
+        return useIndex;
+    }
+
+    public void setUseIndex(Boolean useIndex) {
+        this.useIndex = useIndex;
+    }
+
+    public Integer getIndexListSize() {
+        return indexListSize;
+    }
+
+    public void setIndexListSize(Integer indexListSize) {
+        this.indexListSize = indexListSize;
+    }
+
+    public Boolean getCreateTable() {
+        return createTable;
+    }
+
+    public void setCreateTable(Boolean createTable) {
+        this.createTable = createTable;
+    }
+
+    public Boolean getDropTableFirst() {
+        return dropTableFirst;
+    }
+
+    public void setDropTableFirst(Boolean dropTableFirst) {
+        this.dropTableFirst = dropTableFirst;
+    }
+
+    public Boolean getSkipCreateVectorExtension() {
+        return skipCreateVectorExtension;
+    }
+
+    public void setSkipCreateVectorExtension(Boolean skipCreateVectorExtension) {
+        this.skipCreateVectorExtension = skipCreateVectorExtension;
+    }
+
+    public PgVectorEmbeddingStore.SearchMode getSearchMode() {
+        return searchMode;
+    }
+
+    public void setSearchMode(PgVectorEmbeddingStore.SearchMode searchMode) {
+        this.searchMode = searchMode;
+    }
+
+    public String getTextSearchConfig() {
+        return textSearchConfig;
+    }
+
+    public void setTextSearchConfig(String textSearchConfig) {
+        this.textSearchConfig = textSearchConfig;
+    }
+
+    public Integer getRrfK() {
+        return rrfK;
+    }
+
+    public void setRrfK(Integer rrfK) {
+        this.rrfK = rrfK;
+    }
+
+    public String getDataSourceBeanName() {
+        return dataSourceBeanName;
+    }
+
+    public void setDataSourceBeanName(String dataSourceBeanName) {
+        this.dataSourceBeanName = dataSourceBeanName;
+    }
+}

--- a/langchain4j-pgvector-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/langchain4j-pgvector-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.langchain4j.store.embedding.pgvector.spring.PgVectorEmbeddingStoreAutoConfiguration

--- a/langchain4j-pgvector-spring-boot-starter/src/test/java/dev/langchain4j/store/embedding/pgvector/spring/PgVectorEmbeddingStoreAutoConfigurationIT.java
+++ b/langchain4j-pgvector-spring-boot-starter/src/test/java/dev/langchain4j/store/embedding/pgvector/spring/PgVectorEmbeddingStoreAutoConfigurationIT.java
@@ -1,0 +1,62 @@
+package dev.langchain4j.store.embedding.pgvector.spring;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
+import dev.langchain4j.store.embedding.spring.EmbeddingStoreAutoConfigurationIT;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import static dev.langchain4j.internal.Utils.randomUUID;
+
+class PgVectorEmbeddingStoreAutoConfigurationIT extends EmbeddingStoreAutoConfigurationIT {
+
+    static PostgreSQLContainer<?> pgVector = new PostgreSQLContainer<>("pgvector/pgvector:pg16");
+
+    private String tableName;
+
+    @BeforeAll
+    static void beforeAll() {
+        pgVector.start();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        pgVector.stop();
+    }
+
+    @BeforeEach
+    void setTableName() {
+        tableName = "langchain4j_" + randomUUID().replace("-", "_");
+    }
+
+    @Override
+    protected Class<?> autoConfigurationClass() {
+        return PgVectorEmbeddingStoreAutoConfiguration.class;
+    }
+
+    @Override
+    protected Class<? extends EmbeddingStore<TextSegment>> embeddingStoreClass() {
+        return PgVectorEmbeddingStore.class;
+    }
+
+    @Override
+    protected String[] properties() {
+        return new String[]{
+                "langchain4j.pgvector.host=" + pgVector.getHost(),
+                "langchain4j.pgvector.port=" + pgVector.getMappedPort(5432),
+                "langchain4j.pgvector.user=" + pgVector.getUsername(),
+                "langchain4j.pgvector.password=" + pgVector.getPassword(),
+                "langchain4j.pgvector.database=" + pgVector.getDatabaseName(),
+                "langchain4j.pgvector.table=" + tableName,
+                "langchain4j.pgvector.create-table=true"
+        };
+    }
+
+    @Override
+    protected String dimensionPropertyKey() {
+        return "langchain4j.pgvector.dimension";
+    }
+}

--- a/langchain4j-pgvector-spring-boot-starter/src/test/java/dev/langchain4j/store/embedding/pgvector/spring/PgVectorEmbeddingStoreDataSourceAutoConfigurationIT.java
+++ b/langchain4j-pgvector-spring-boot-starter/src/test/java/dev/langchain4j/store/embedding/pgvector/spring/PgVectorEmbeddingStoreDataSourceAutoConfigurationIT.java
@@ -1,0 +1,191 @@
+package dev.langchain4j.store.embedding.pgvector.spring;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingSearchResult;
+import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import static dev.langchain4j.internal.Utils.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PgVectorEmbeddingStoreDataSourceAutoConfigurationIT {
+
+    static PostgreSQLContainer<?> pgVector = new PostgreSQLContainer<>("pgvector/pgvector:pg16");
+
+    @BeforeAll
+    static void beforeAll() {
+        pgVector.start();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        pgVector.stop();
+    }
+
+    private String randomTable() {
+        return "langchain4j_" + randomUUID().replace("-", "_");
+    }
+
+    @Test
+    void should_create_embedding_store_using_existing_datasource() {
+        String tableName = randomTable();
+
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        DataSourceAutoConfiguration.class,
+                        PgVectorEmbeddingStoreAutoConfiguration.class))
+                .withPropertyValues(
+                        "spring.datasource.url=" + pgVector.getJdbcUrl(),
+                        "spring.datasource.username=" + pgVector.getUsername(),
+                        "spring.datasource.password=" + pgVector.getPassword(),
+                        "langchain4j.pgvector.table=" + tableName,
+                        "langchain4j.pgvector.dimension=384",
+                        "langchain4j.pgvector.create-table=true"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(PgVectorEmbeddingStore.class);
+
+                    PgVectorEmbeddingStore store = context.getBean(PgVectorEmbeddingStore.class);
+                    EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
+                    TextSegment segment = TextSegment.from("test with existing datasource");
+                    Embedding embedding = embeddingModel.embed(segment.text()).content();
+
+                    String id = store.add(embedding, segment);
+                    assertThat(id).isNotBlank();
+
+                    EmbeddingSearchResult<TextSegment> result = store.search(
+                            EmbeddingSearchRequest.builder()
+                                    .queryEmbedding(embedding)
+                                    .maxResults(1)
+                                    .build());
+                    assertThat(result.matches()).hasSize(1);
+                    assertThat(result.matches().get(0).embedded()).isEqualTo(segment);
+                });
+    }
+
+    @Test
+    void should_fail_when_no_postgres_datasource_and_no_explicit_properties() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        PgVectorEmbeddingStoreAutoConfiguration.class))
+                .withPropertyValues(
+                        "langchain4j.pgvector.table=test_table",
+                        "langchain4j.pgvector.dimension=384",
+                        "langchain4j.pgvector.create-table=true"
+                )
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure())
+                            .rootCause()
+                            .isInstanceOf(IllegalStateException.class)
+                            .hasMessageContaining("No suitable PostgreSQL DataSource found");
+                });
+    }
+
+    @Test
+    void should_fail_when_non_postgres_datasource_present_and_no_explicit_properties() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        DataSourceAutoConfiguration.class,
+                        PgVectorEmbeddingStoreAutoConfiguration.class))
+                .withPropertyValues(
+                        "spring.datasource.url=jdbc:h2:mem:testdb",
+                        "spring.datasource.driver-class-name=org.h2.Driver",
+                        "langchain4j.pgvector.table=test_table",
+                        "langchain4j.pgvector.dimension=384",
+                        "langchain4j.pgvector.create-table=true"
+                )
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure())
+                            .rootCause()
+                            .isInstanceOf(IllegalStateException.class)
+                            .hasMessageContaining("No suitable PostgreSQL DataSource found");
+                });
+    }
+
+    @Test
+    void should_not_create_bean_when_disabled() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        PgVectorEmbeddingStoreAutoConfiguration.class))
+                .withPropertyValues("langchain4j.pgvector.enabled=false")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(PgVectorEmbeddingStore.class);
+                });
+    }
+
+    @Test
+    void should_prefer_explicit_properties_over_datasource() {
+        String tableName = randomTable();
+
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        DataSourceAutoConfiguration.class,
+                        PgVectorEmbeddingStoreAutoConfiguration.class))
+                .withPropertyValues(
+                        // Spring DataSource pointing to the same PG for simplicity
+                        "spring.datasource.url=" + pgVector.getJdbcUrl(),
+                        "spring.datasource.username=" + pgVector.getUsername(),
+                        "spring.datasource.password=" + pgVector.getPassword(),
+                        // Explicit pgvector properties — these should take priority
+                        "langchain4j.pgvector.host=" + pgVector.getHost(),
+                        "langchain4j.pgvector.port=" + pgVector.getMappedPort(5432),
+                        "langchain4j.pgvector.user=" + pgVector.getUsername(),
+                        "langchain4j.pgvector.password=" + pgVector.getPassword(),
+                        "langchain4j.pgvector.database=" + pgVector.getDatabaseName(),
+                        "langchain4j.pgvector.table=" + tableName,
+                        "langchain4j.pgvector.dimension=384",
+                        "langchain4j.pgvector.create-table=true"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(PgVectorEmbeddingStore.class);
+
+                    PgVectorEmbeddingStore store = context.getBean(PgVectorEmbeddingStore.class);
+                    EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
+                    Embedding embedding = embeddingModel.embed("test").content();
+
+                    String id = store.add(embedding, TextSegment.from("test"));
+                    assertThat(id).isNotBlank();
+                });
+    }
+
+    @Test
+    void should_use_embedding_model_dimension_when_not_specified() {
+        String tableName = randomTable();
+
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        DataSourceAutoConfiguration.class,
+                        PgVectorEmbeddingStoreAutoConfiguration.class))
+                .withBean(AllMiniLmL6V2QuantizedEmbeddingModel.class)
+                .withPropertyValues(
+                        "spring.datasource.url=" + pgVector.getJdbcUrl(),
+                        "spring.datasource.username=" + pgVector.getUsername(),
+                        "spring.datasource.password=" + pgVector.getPassword(),
+                        "langchain4j.pgvector.table=" + tableName,
+                        "langchain4j.pgvector.create-table=true"
+                        // Note: no dimension property — should fall back to EmbeddingModel
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(PgVectorEmbeddingStore.class);
+
+                    PgVectorEmbeddingStore store = context.getBean(PgVectorEmbeddingStore.class);
+                    EmbeddingModel embeddingModel = context.getBean(AllMiniLmL6V2QuantizedEmbeddingModel.class);
+                    Embedding embedding = embeddingModel.embed("dimension fallback test").content();
+
+                    String id = store.add(embedding, TextSegment.from("dimension fallback test"));
+                    assertThat(id).isNotBlank();
+                });
+    }
+}

--- a/langchain4j-pgvector-spring-boot-starter/src/test/java/dev/langchain4j/store/embedding/pgvector/spring/PgVectorEmbeddingStoreDataSourceAutoConfigurationIT.java
+++ b/langchain4j-pgvector-spring-boot-starter/src/test/java/dev/langchain4j/store/embedding/pgvector/spring/PgVectorEmbeddingStoreDataSourceAutoConfigurationIT.java
@@ -134,10 +134,9 @@ class PgVectorEmbeddingStoreDataSourceAutoConfigurationIT {
                         DataSourceAutoConfiguration.class,
                         PgVectorEmbeddingStoreAutoConfiguration.class))
                 .withPropertyValues(
-                        // Spring DataSource pointing to the same PG for simplicity
-                        "spring.datasource.url=" + pgVector.getJdbcUrl(),
-                        "spring.datasource.username=" + pgVector.getUsername(),
-                        "spring.datasource.password=" + pgVector.getPassword(),
+                        // Spring DataSource is H2 — if auto-config fell through to DataSource path, it would fail
+                        "spring.datasource.url=jdbc:h2:mem:testdb",
+                        "spring.datasource.driver-class-name=org.h2.Driver",
                         // Explicit pgvector properties — these should take priority
                         "langchain4j.pgvector.host=" + pgVector.getHost(),
                         "langchain4j.pgvector.port=" + pgVector.getMappedPort(5432),

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <module>langchain4j-milvus-spring-boot4-starter</module>
         <module>langchain4j-mistral-ai-spring-boot-starter</module>
         <module>langchain4j-mistral-ai-spring-boot4-starter</module>
+        <module>langchain4j-pgvector-spring-boot-starter</module>
 
         <module>langchain4j-reactor</module>
     </modules>


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                       
  - Adds Spring Boot starter for langchain4j-pgvector with auto-configuration
  - Reuses existing Spring DataSource (auto-detects PostgreSQL via JDBC URL)                                                                                                                                                       
  - Falls back to explicit host/port/user/password properties when no DataSource available                                                                                                                                         
  - Supports dataSourceBeanName for multi-DataSource environments
  - Wraps DataSource in TransactionAwareDataSourceProxy for @Transactional support (#2614)                                                                                                                                         
  - Falls back to EmbeddingModel.dimension() when dimension not explicitly configured                                                                                                                                              
  - Exposes all PgVector builder options: searchMode, textSearchConfig, rrfK, etc.
  - 8 integration tests with Testcontainers (pgvector/pgvector:pg16)                                                                                                                                                               
                                                                                                                                                                                                                                   
Builds on the maintainer feedback from the previous attempt in #76
                                                                                                                                                                                                                                   
  ## Test plan                                                                                                                                                                                                                     
  - [x] mvn clean verify passes locally with Docker (8/8 tests green)
  - [x] Existing Postgres DataSource auto-detected
  - [x] Non-Postgres (H2) DataSource correctly rejected
  - [x] Explicit properties take priority over DataSource (proven via H2 fallback test)                                                                                                                                            
  - [x] EmbeddingModel dimension fallback works
  - [x] Disabled config produces no bean                                                                                                                                                                                           
                                                                                                                                                                                                                                   
  Fixes langchain4j/langchain4j#2102
