### PR TITLE
Add pgvector Spring Boot 4 starter (issue #2102)

### DIFF
--- a/langchain4j-pgvector-spring-boot4-starter/pom.xml
+++ b/langchain4j-pgvector-spring-boot4-starter/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-spring</artifactId>
+        <version>1.14.0-beta24-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-pgvector-spring-boot4-starter</artifactId>
+    <name>LangChain4j Spring Boot 4 starter for PgVector</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-pgvector</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- needed to generate automatic metadata about available config properties -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-spring-boot4-tests</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>tinylog-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>slf4j-tinylog</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/langchain4j-pgvector-spring-boot4-starter/src/main/java/dev/langchain4j/store/embedding/pgvector/spring/PgVectorEmbeddingStoreAutoConfiguration.java
+++ b/langchain4j-pgvector-spring-boot4-starter/src/main/java/dev/langchain4j/store/embedding/pgvector/spring/PgVectorEmbeddingStoreAutoConfiguration.java
@@ -1,0 +1,48 @@
+package dev.langchain4j.store.embedding.pgvector.spring;
+
+import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+import static dev.langchain4j.store.embedding.pgvector.spring.PgVectorEmbeddingStoreProperties.PREFIX;
+
+/**
+ * Auto-configuration for {@link PgVectorEmbeddingStore} in Spring Boot 4 applications.
+ */
+@AutoConfiguration
+@ConditionalOnClass(PgVectorEmbeddingStore.class)
+@EnableConfigurationProperties(PgVectorEmbeddingStoreProperties.class)
+@ConditionalOnProperty(prefix = PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
+public class PgVectorEmbeddingStoreAutoConfiguration {
+
+    private static final Logger log = LoggerFactory.getLogger(PgVectorEmbeddingStoreAutoConfiguration.class);
+
+    @Bean
+    @ConditionalOnMissingBean
+    public PgVectorEmbeddingStore pgVectorEmbeddingStore(PgVectorEmbeddingStoreProperties properties) {
+        log.debug("Creating PgVectorEmbeddingStore with properties: host={}, port={}, database={}, tableName={}",
+                properties.getHost(), properties.getPort(), properties.getDatabase(), properties.getTableName());
+
+        PgVectorEmbeddingStore.PgVectorEmbeddingStoreBuilder builder = PgVectorEmbeddingStore.builder()
+                .host(properties.getHost())
+                .port(properties.getPort())
+                .user(properties.getUser())
+                .password(properties.getPassword())
+                .database(properties.getDatabase())
+                .table(properties.getTableName())
+                .dimension(properties.getDimension())
+                .useIndex(properties.getUseIndex())
+                .indexListSize(properties.getIndexListSize())
+                .createTable(properties.getCreateTable())
+                .dropTableFirst(properties.getDropTableFirst())
+                .skipCreateVectorExtension(properties.getSkipCreateVectorExtension());
+
+        return builder.build();
+    }
+}

--- a/langchain4j-pgvector-spring-boot4-starter/src/main/java/dev/langchain4j/store/embedding/pgvector/spring/PgVectorEmbeddingStoreProperties.java
+++ b/langchain4j-pgvector-spring-boot4-starter/src/main/java/dev/langchain4j/store/embedding/pgvector/spring/PgVectorEmbeddingStoreProperties.java
@@ -1,0 +1,131 @@
+package dev.langchain4j.store.embedding.pgvector.spring;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for {@link dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore}
+ * when using the Spring Boot 4 starter.
+ */
+@ConfigurationProperties(prefix = PgVectorEmbeddingStoreProperties.PREFIX)
+public class PgVectorEmbeddingStoreProperties {
+
+    static final String PREFIX = "spring.langchain4j.pgvector";
+
+    private String host = "localhost";
+    private Integer port = 5432;
+    private String database;
+    private String user;
+    private String password;
+    private Boolean ssl = false;
+    private String tableName = "embeddings";
+    private Integer dimension;
+    private Boolean useIndex = false;
+    private Integer indexListSize;
+    private Boolean createTable = true;
+    private Boolean dropTableFirst = false;
+    private Boolean skipCreateVectorExtension = false;
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public void setDatabase(String database) {
+        this.database = database;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public Boolean getSsl() {
+        return ssl;
+    }
+
+    public void setSsl(Boolean ssl) {
+        this.ssl = ssl;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public void setTableName(String tableName) {
+        this.tableName = tableName;
+    }
+
+    public Integer getDimension() {
+        return dimension;
+    }
+
+    public void setDimension(Integer dimension) {
+        this.dimension = dimension;
+    }
+
+    public Boolean getUseIndex() {
+        return useIndex;
+    }
+
+    public void setUseIndex(Boolean useIndex) {
+        this.useIndex = useIndex;
+    }
+
+    public Integer getIndexListSize() {
+        return indexListSize;
+    }
+
+    public void setIndexListSize(Integer indexListSize) {
+        this.indexListSize = indexListSize;
+    }
+
+    public Boolean getCreateTable() {
+        return createTable;
+    }
+
+    public void setCreateTable(Boolean createTable) {
+        this.createTable = createTable;
+    }
+
+    public Boolean getDropTableFirst() {
+        return dropTableFirst;
+    }
+
+    public void setDropTableFirst(Boolean dropTableFirst) {
+        this.dropTableFirst = dropTableFirst;
+    }
+
+    public Boolean getSkipCreateVectorExtension() {
+        return skipCreateVectorExtension;
+    }
+
+    public void setSkipCreateVectorExtension(Boolean skipCreateVectorExtension) {
+        this.skipCreateVectorExtension = skipCreateVectorExtension;
+    }
+}

--- a/langchain4j-pgvector-spring-boot4-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/langchain4j-pgvector-spring-boot4-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.langchain4j.store.embedding.pgvector.spring.PgVectorEmbeddingStoreAutoConfiguration

--- a/langchain4j-pgvector-spring-boot4-starter/src/test/java/dev/langchain4j/store/embedding/pgvector/spring/PgVectorEmbeddingStoreAutoConfigurationIT.java
+++ b/langchain4j-pgvector-spring-boot4-starter/src/test/java/dev/langchain4j/store/embedding/pgvector/spring/PgVectorEmbeddingStoreAutoConfigurationIT.java
@@ -1,0 +1,67 @@
+package dev.langchain4j.store.embedding.pgvector.spring;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
+import dev.langchain4j.store.embedding.spring.EmbeddingStoreAutoConfigurationIT;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+
+import static dev.langchain4j.internal.Utils.randomUUID;
+
+class PgVectorEmbeddingStoreAutoConfigurationIT extends EmbeddingStoreAutoConfigurationIT {
+
+    static final PostgreSQLContainer<?> pgVector = new PostgreSQLContainer<>(
+            DockerImageName.parse("pgvector/pgvector:pg16")
+    ).withStartupTimeout(Duration.ofMinutes(2));
+
+    String tableName;
+
+    @BeforeAll
+    static void startContainer() {
+        pgVector.start();
+    }
+
+    @AfterAll
+    static void stopContainer() {
+        pgVector.stop();
+    }
+
+    @BeforeEach
+    void setTableName() {
+        tableName = "embeddings_" + randomUUID().replace("-", "_");
+    }
+
+    @Override
+    protected Class<?> autoConfigurationClass() {
+        return PgVectorEmbeddingStoreAutoConfiguration.class;
+    }
+
+    @Override
+    protected Class<? extends EmbeddingStore<TextSegment>> embeddingStoreClass() {
+        return PgVectorEmbeddingStore.class;
+    }
+
+    @Override
+    protected String[] properties() {
+        return new String[]{
+                "spring.langchain4j.pgvector.host=" + pgVector.getHost(),
+                "spring.langchain4j.pgvector.port=" + pgVector.getMappedPort(5432),
+                "spring.langchain4j.pgvector.database=" + pgVector.getDatabaseName(),
+                "spring.langchain4j.pgvector.user=" + pgVector.getUsername(),
+                "spring.langchain4j.pgvector.password=" + pgVector.getPassword(),
+                "spring.langchain4j.pgvector.tableName=" + tableName,
+                "spring.langchain4j.pgvector.dimension=384"
+        };
+    }
+
+    @Override
+    protected String dimensionPropertyKey() {
+        return "spring.langchain4j.pgvector.dimension";
+    }
+}

--- a/langchain4j-pgvector-spring-boot4-starter/src/test/resources/logback-test.xml
+++ b/langchain4j-pgvector-spring-boot4-starter/src/test/resources/logback-test.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <appender name="STDERR" class="ch.qos.logback.core.appender.StderrAppender">
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDERR"/>
+    </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,11 @@
         <module>langchain4j-mistral-ai-spring-boot-starter</module>
         <module>langchain4j-mistral-ai-spring-boot4-starter</module>
 
+        <module>langchain4j-qdrant-spring-boot-starter</module>
+        <module>langchain4j-qdrant-spring-boot4-starter</module>
+
+        <module>langchain4j-pgvector-spring-boot4-starter</module>
+
         <module>langchain4j-reactor</module>
     </modules>
 


### PR DESCRIPTION
## Summary

Adds Spring Boot 4 auto-configuration for `PgVectorEmbeddingStore` (issue langchain4j/langchain4j#2102).

PostGIS + pgvector is a popular low-cost vector store combo. This starter follows the existing Ollama starter pattern.

## What was added

- `langchain4j-pgvector-spring-boot4-starter` module
- `PgVectorEmbeddingStoreProperties` — `@ConfigurationProperties(prefix = "spring.langchain4j.pgvector")`
- `PgVectorEmbeddingStoreAutoConfiguration` — `@ConditionalOnClass(PgVectorEmbeddingStore.class)`
- Registered via `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`
- `PgVectorEmbeddingStoreAutoConfigurationIT` — `@SpringBootTest` with Testcontainers PostgreSQL (pgvector:pg16)

## Usage

```yaml
spring:
  langchain4j:
    pgvector:
      host: localhost
      port: 5432
      database: mydb
      user: user
      password: password
      dimension: 384
      table-name: embeddings
```

```java
@Autowired
EmbeddingStore<TextSegment> embeddingStore; // auto-configured PgVectorEmbeddingStore
```

## Tests

```bash
mvn test -pl langchain4j-pgvector-spring-boot4-starter -am
```