### PR TITLE
Add assertEmbedding() in EmbeddingStoreAutoConfigurationIT

### DIFF
--- a/langchain4j-spring-boot-tests/src/test/java/dev/langchain4j/store/embedding/spring/EmbeddingStoreAutoConfigurationIT.java
+++ b/langchain4j-spring-boot-tests/src/test/java/dev/langchain4j/store/embedding/spring/EmbeddingStoreAutoConfigurationIT.java
@@ -71,7 +71,9 @@ public abstract class EmbeddingStoreAutoConfigurationIT {
                     EmbeddingMatch<TextSegment> match = relevant.get(0);
                     assertThat(match.score()).isCloseTo(1, withPercentage(1));
                     assertThat(match.embeddingId()).isEqualTo(id);
-                    assertThat(match.embedding()).isEqualTo(embedding);
+                    if (assertEmbedding()) {
+                        assertThat(match.embedding()).isEqualTo(embedding);
+                    }
                     assertThat(match.embedded()).isEqualTo(segment);
                 });
     }
@@ -105,12 +107,18 @@ public abstract class EmbeddingStoreAutoConfigurationIT {
                     EmbeddingMatch<TextSegment> match = matches.get(0);
                     assertThat(match.score()).isCloseTo(1, withPercentage(1));
                     assertThat(match.embeddingId()).isEqualTo(id);
-                    assertThat(match.embedding()).isEqualTo(embedding);
+                    if (assertEmbedding()) {
+                        assertThat(match.embedding()).isEqualTo(embedding);
+                    }
                     assertThat(match.embedded()).isEqualTo(segment);
                 });
     }
 
     protected void awaitUntilPersisted(ApplicationContext context) {
 
+    }
+
+    protected boolean assertEmbedding() {
+        return true;
     }
 }


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Goal: To enable `EmbeddingStoreAutoConfigurationIT` to have the same control over asserting embeddings as `EmbeddingStoreIT` / `EmbeddingStoreWithFilteringIT`, thereby providing greater testing flexibility for embedding stores where embeddings cannot be asserted precisely.

## Change
<!-- Please describe the changes you made. -->

Add `assertEmbedding()` in `EmbeddingStoreAutoConfigurationIT` like `EmbeddingStoreWithoutMetadataIT`


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
