### PR TITLE
docs: rebrand Azure Cosmos DB for MongoDB vCore -> Azure DocumentDB

### DIFF
--- a/langchain4j-azure-cosmos-mongo-vcore-spring-boot-starter/pom.xml
+++ b/langchain4j-azure-cosmos-mongo-vcore-spring-boot-starter/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>langchain4j-azure-cosmos-mongo-vcore-spring-boot-starter</artifactId>
-    <name>LangChain4j Spring Boot starter for Azure Cosmos DB Mongo vCore</name>
+    <name>LangChain4j Spring Boot starter for Azure DocumentDB (with MongoDB compatibility)</name>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/langchain4j-azure-cosmos-mongo-vcore-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/azure/cosmos/mongo/vcore/spring/AzureCosmosDbMongoVCoreEmbeddingStoreProperties.java
+++ b/langchain4j-azure-cosmos-mongo-vcore-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/azure/cosmos/mongo/vcore/spring/AzureCosmosDbMongoVCoreEmbeddingStoreProperties.java
@@ -3,7 +3,7 @@ package dev.langchain4j.store.embedding.azure.cosmos.mongo.vcore.spring;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
- * Configuration properties for Azure Cosmos DB for MongoDB vCore Embedding Store.
+ * Configuration properties for the Azure DocumentDB (with MongoDB compatibility) Embedding Store.
  * <p>
  * Properties are prefixed with {@code langchain4j.azure.cosmos-mongo-vcore}.
  * </p>
@@ -26,7 +26,7 @@ public class AzureCosmosDbMongoVCoreEmbeddingStoreProperties {
     static final String PREFIX = "langchain4j.azure.cosmos-mongo-vcore";
 
     /**
-     * The MongoDB connection string for Azure Cosmos DB for MongoDB vCore.
+     * The MongoDB connection string for Azure DocumentDB.
      */
     private String connectionString;
 

--- a/langchain4j-azure-cosmos-mongo-vcore-spring-boot4-starter/pom.xml
+++ b/langchain4j-azure-cosmos-mongo-vcore-spring-boot4-starter/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>langchain4j-azure-cosmos-mongo-vcore-spring-boot4-starter</artifactId>
-    <name>LangChain4j Spring Boot 4 starter for Azure Cosmos DB Mongo vCore</name>
+    <name>LangChain4j Spring Boot 4 starter for Azure DocumentDB (with MongoDB compatibility)</name>
     <packaging>jar</packaging>
 
     <dependencyManagement>

--- a/langchain4j-azure-cosmos-mongo-vcore-spring-boot4-starter/src/main/java/dev/langchain4j/store/embedding/azure/cosmos/mongo/vcore/spring/AzureCosmosDbMongoVCoreEmbeddingStoreProperties.java
+++ b/langchain4j-azure-cosmos-mongo-vcore-spring-boot4-starter/src/main/java/dev/langchain4j/store/embedding/azure/cosmos/mongo/vcore/spring/AzureCosmosDbMongoVCoreEmbeddingStoreProperties.java
@@ -3,7 +3,7 @@ package dev.langchain4j.store.embedding.azure.cosmos.mongo.vcore.spring;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
- * Configuration properties for Azure Cosmos DB for MongoDB vCore Embedding Store.
+ * Configuration properties for the Azure DocumentDB (with MongoDB compatibility) Embedding Store.
  * <p>
  * Properties are prefixed with {@code langchain4j.azure.cosmos-mongo-vcore}.
  * </p>
@@ -26,7 +26,7 @@ public class AzureCosmosDbMongoVCoreEmbeddingStoreProperties {
     static final String PREFIX = "langchain4j.azure.cosmos-mongo-vcore";
 
     /**
-     * The MongoDB connection string for Azure Cosmos DB for MongoDB vCore.
+     * The MongoDB connection string for Azure DocumentDB.
      */
     private String connectionString;
 


### PR DESCRIPTION
## Summary

Microsoft has renamed the managed MongoDB-compatible service from **Azure Cosmos DB for MongoDB vCore** to **Azure DocumentDB (with MongoDB compatibility)**. Wire protocol, connection strings, drivers, and APIs are unchanged.

This PR updates user-visible product references (Maven artifact display names and Javadoc) in the two starter modules to the new name. **No code identifiers are touched** — package paths, `artifactId`s, class names, and the `langchain4j.azure.cosmos-mongo-vcore` configuration prefix are all preserved, so this is fully backward compatible.

See: https://learn.microsoft.com/azure/documentdb/

## Convention used
- First reference per file: **Azure DocumentDB (with MongoDB compatibility)**
- Subsequent references: **Azure DocumentDB**

## Files changed
- `langchain4j-azure-cosmos-mongo-vcore-spring-boot-starter/pom.xml` — `<name>` tag
- `langchain4j-azure-cosmos-mongo-vcore-spring-boot-starter/.../AzureCosmosDbMongoVCoreEmbeddingStoreProperties.java` — Javadoc only
- `langchain4j-azure-cosmos-mongo-vcore-spring-boot4-starter/pom.xml` — `<name>` tag
- `langchain4j-azure-cosmos-mongo-vcore-spring-boot4-starter/.../AzureCosmosDbMongoVCoreEmbeddingStoreProperties.java` — Javadoc only

A separate, similar PR can be opened against `langchain4j/langchain4j` for the core integration module + the integration docs page if maintainers find this acceptable.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
