### PR TITLE
Feat/chroma spring boot4 starter

### DIFF
--- a/langchain4j-chroma-spring-boot-starter/pom.xml
+++ b/langchain4j-chroma-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-spring</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>1.14.0-beta24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/langchain4j-chroma-spring-boot-starter/pom.xml
+++ b/langchain4j-chroma-spring-boot-starter/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-spring</artifactId>
+        <version>1.14.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-chroma-spring-boot-starter</artifactId>
+    <name>LangChain4j :: Spring Boot Starter :: Chroma</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-chroma</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/langchain4j-chroma-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreAutoConfiguration.java
+++ b/langchain4j-chroma-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreAutoConfiguration.java
@@ -1,0 +1,46 @@
+package dev.langchain4j.store.embedding.chroma.spring;
+
+import dev.langchain4j.store.embedding.chroma.ChromaEmbeddingStore;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+import java.util.Optional;
+
+import static dev.langchain4j.store.embedding.chroma.spring.ChromaEmbeddingStoreProperties.*;
+
+@AutoConfiguration
+@EnableConfigurationProperties(ChromaEmbeddingStoreProperties.class)
+@ConditionalOnProperty(prefix = PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
+public class ChromaEmbeddingStoreAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ChromaEmbeddingStore chromaEmbeddingStore(ChromaEmbeddingStoreProperties properties) {
+
+        ChromaEmbeddingStore.Builder builder = ChromaEmbeddingStore.builder()
+                .baseUrl(Optional.ofNullable(properties.getBaseUrl()).orElse(DEFAULT_BASE_URL))
+                .collectionName(Optional.ofNullable(properties.getCollectionName()).orElse(DEFAULT_COLLECTION_NAME))
+                .timeout(Optional.ofNullable(properties.getTimeout()).orElse(DEFAULT_TIMEOUT));
+
+        if (properties.getTenantName() != null) {
+            builder.tenantName(properties.getTenantName());
+        }
+        if (properties.getDatabaseName() != null) {
+            builder.databaseName(properties.getDatabaseName());
+        }
+        if (properties.getApiVersion() != null) {
+            builder.apiVersion(properties.getApiVersion());
+        }
+        if (properties.getLogRequests() != null) {
+            builder.logRequests(properties.getLogRequests());
+        }
+        if (properties.getLogResponses() != null) {
+            builder.logResponses(properties.getLogResponses());
+        }
+
+        return builder.build();
+    }
+}

--- a/langchain4j-chroma-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreProperties.java
+++ b/langchain4j-chroma-spring-boot-starter/src/main/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreProperties.java
@@ -1,0 +1,47 @@
+package dev.langchain4j.store.embedding.chroma.spring;
+
+import dev.langchain4j.store.embedding.chroma.ChromaApiVersion;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import java.time.Duration;
+
+@ConfigurationProperties(prefix = ChromaEmbeddingStoreProperties.PREFIX)
+public class ChromaEmbeddingStoreProperties {
+
+    static final String PREFIX = "langchain4j.chroma";
+    static final String DEFAULT_BASE_URL = "http://localhost:8000";
+    static final String DEFAULT_COLLECTION_NAME = "default";
+    static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
+
+    private String baseUrl;
+    private String collectionName;
+    private String tenantName;
+    private String databaseName;
+    private Duration timeout;
+    private Boolean logRequests;
+    private Boolean logResponses;
+    private ChromaApiVersion apiVersion;
+
+    public String getBaseUrl() { return baseUrl; }
+    public void setBaseUrl(String baseUrl) { this.baseUrl = baseUrl; }
+
+    public String getCollectionName() { return collectionName; }
+    public void setCollectionName(String collectionName) { this.collectionName = collectionName; }
+
+    public String getTenantName() { return tenantName; }
+    public void setTenantName(String tenantName) { this.tenantName = tenantName; }
+
+    public String getDatabaseName() { return databaseName; }
+    public void setDatabaseName(String databaseName) { this.databaseName = databaseName; }
+
+    public Duration getTimeout() { return timeout; }
+    public void setTimeout(Duration timeout) { this.timeout = timeout; }
+
+    public Boolean getLogRequests() { return logRequests; }
+    public void setLogRequests(Boolean logRequests) { this.logRequests = logRequests; }
+
+    public Boolean getLogResponses() { return logResponses; }
+    public void setLogResponses(Boolean logResponses) { this.logResponses = logResponses; }
+
+    public ChromaApiVersion getApiVersion() { return apiVersion; }
+    public void setApiVersion(ChromaApiVersion apiVersion) { this.apiVersion = apiVersion; }
+}

--- a/langchain4j-chroma-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/langchain4j-chroma-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.langchain4j.store.embedding.chroma.spring.ChromaEmbeddingStoreAutoConfiguration

--- a/langchain4j-chroma-spring-boot-starter/src/test/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreAutoConfigurationIT.java
+++ b/langchain4j-chroma-spring-boot-starter/src/test/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreAutoConfigurationIT.java
@@ -1,0 +1,46 @@
+package dev.langchain4j.store.embedding.chroma.spring;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.chroma.ChromaEmbeddingStore;
+import dev.langchain4j.store.embedding.spring.EmbeddingStoreAutoConfigurationIT;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.testcontainers.chromadb.ChromaDBContainer;
+
+class ChromaEmbeddingStoreAutoConfigurationIT extends EmbeddingStoreAutoConfigurationIT {
+
+    static ChromaDBContainer chroma = new ChromaDBContainer("chromadb/chroma:0.5.0");
+
+    @BeforeAll
+    static void beforeAll() {
+        chroma.start();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        chroma.stop();
+    }
+
+    @Override
+    protected Class<?> autoConfigurationClass() {
+        return ChromaEmbeddingStoreAutoConfiguration.class;
+    }
+
+    @Override
+    protected Class<? extends EmbeddingStore<TextSegment>> embeddingStoreClass() {
+        return ChromaEmbeddingStore.class;
+    }
+
+    @Override
+    protected String[] properties() {
+        return new String[]{
+                "langchain4j.chroma.baseUrl=" + chroma.getEndpoint()
+        };
+    }
+
+    @Override
+    protected String dimensionPropertyKey() {
+        return "langchain4j.chroma.dimension";
+    }
+}

--- a/langchain4j-chroma-spring-boot4-starter/pom.xml
+++ b/langchain4j-chroma-spring-boot4-starter/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-spring</artifactId>
+        <version>1.15.0-beta25-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-chroma-spring-boot4-starter</artifactId>
+    <name>LangChain4j Spring Boot 4 starter for Chroma</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Override Spring Boot version from parent -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot4.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-chroma</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/langchain4j-chroma-spring-boot4-starter/pom.xml
+++ b/langchain4j-chroma-spring-boot4-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-spring</artifactId>
-        <version>1.15.0-beta25-SNAPSHOT</version>
+        <version>1.18.0-beta28-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/langchain4j-chroma-spring-boot4-starter/src/main/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreAutoConfiguration.java
+++ b/langchain4j-chroma-spring-boot4-starter/src/main/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreAutoConfiguration.java
@@ -1,0 +1,46 @@
+package dev.langchain4j.store.embedding.chroma.spring;
+
+import dev.langchain4j.store.embedding.chroma.ChromaEmbeddingStore;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+import java.util.Optional;
+
+import static dev.langchain4j.store.embedding.chroma.spring.ChromaEmbeddingStoreProperties.*;
+
+@AutoConfiguration
+@EnableConfigurationProperties(ChromaEmbeddingStoreProperties.class)
+@ConditionalOnProperty(prefix = PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
+public class ChromaEmbeddingStoreAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ChromaEmbeddingStore chromaEmbeddingStore(ChromaEmbeddingStoreProperties properties) {
+
+        ChromaEmbeddingStore.Builder builder = ChromaEmbeddingStore.builder()
+                .baseUrl(Optional.ofNullable(properties.getBaseUrl()).orElse(DEFAULT_BASE_URL))
+                .collectionName(Optional.ofNullable(properties.getCollectionName()).orElse(DEFAULT_COLLECTION_NAME))
+                .timeout(Optional.ofNullable(properties.getTimeout()).orElse(DEFAULT_TIMEOUT));
+
+        if (properties.getTenantName() != null) {
+            builder.tenantName(properties.getTenantName());
+        }
+        if (properties.getDatabaseName() != null) {
+            builder.databaseName(properties.getDatabaseName());
+        }
+        if (properties.getApiVersion() != null) {
+            builder.apiVersion(properties.getApiVersion());
+        }
+        if (properties.getLogRequests() != null) {
+            builder.logRequests(properties.getLogRequests());
+        }
+        if (properties.getLogResponses() != null) {
+            builder.logResponses(properties.getLogResponses());
+        }
+
+        return builder.build();
+    }
+}

--- a/langchain4j-chroma-spring-boot4-starter/src/main/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreAutoConfiguration.java
+++ b/langchain4j-chroma-spring-boot4-starter/src/main/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreAutoConfiguration.java
@@ -3,7 +3,7 @@ package dev.langchain4j.store.embedding.chroma.spring;
 import dev.langchain4j.store.embedding.chroma.ChromaEmbeddingStore;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
@@ -13,7 +13,7 @@ import static dev.langchain4j.store.embedding.chroma.spring.ChromaEmbeddingStore
 
 @AutoConfiguration
 @EnableConfigurationProperties(ChromaEmbeddingStoreProperties.class)
-@ConditionalOnProperty(prefix = PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnBooleanProperty(prefix = PREFIX, name = "enabled", matchIfMissing = true)
 public class ChromaEmbeddingStoreAutoConfiguration {
 
     @Bean

--- a/langchain4j-chroma-spring-boot4-starter/src/main/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreProperties.java
+++ b/langchain4j-chroma-spring-boot4-starter/src/main/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreProperties.java
@@ -1,0 +1,47 @@
+package dev.langchain4j.store.embedding.chroma.spring;
+
+import dev.langchain4j.store.embedding.chroma.ChromaApiVersion;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import java.time.Duration;
+
+@ConfigurationProperties(prefix = ChromaEmbeddingStoreProperties.PREFIX)
+public class ChromaEmbeddingStoreProperties {
+
+    static final String PREFIX = "langchain4j.chroma";
+    static final String DEFAULT_BASE_URL = "http://localhost:8000";
+    static final String DEFAULT_COLLECTION_NAME = "default";
+    static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
+
+    private String baseUrl;
+    private String collectionName;
+    private String tenantName;
+    private String databaseName;
+    private Duration timeout;
+    private Boolean logRequests;
+    private Boolean logResponses;
+    private ChromaApiVersion apiVersion;
+
+    public String getBaseUrl() { return baseUrl; }
+    public void setBaseUrl(String baseUrl) { this.baseUrl = baseUrl; }
+
+    public String getCollectionName() { return collectionName; }
+    public void setCollectionName(String collectionName) { this.collectionName = collectionName; }
+
+    public String getTenantName() { return tenantName; }
+    public void setTenantName(String tenantName) { this.tenantName = tenantName; }
+
+    public String getDatabaseName() { return databaseName; }
+    public void setDatabaseName(String databaseName) { this.databaseName = databaseName; }
+
+    public Duration getTimeout() { return timeout; }
+    public void setTimeout(Duration timeout) { this.timeout = timeout; }
+
+    public Boolean getLogRequests() { return logRequests; }
+    public void setLogRequests(Boolean logRequests) { this.logRequests = logRequests; }
+
+    public Boolean getLogResponses() { return logResponses; }
+    public void setLogResponses(Boolean logResponses) { this.logResponses = logResponses; }
+
+    public ChromaApiVersion getApiVersion() { return apiVersion; }
+    public void setApiVersion(ChromaApiVersion apiVersion) { this.apiVersion = apiVersion; }
+}

--- a/langchain4j-chroma-spring-boot4-starter/src/main/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreProperties.java
+++ b/langchain4j-chroma-spring-boot4-starter/src/main/java/dev/langchain4j/store/embedding/chroma/spring/ChromaEmbeddingStoreProperties.java
@@ -2,8 +2,10 @@ package dev.langchain4j.store.embedding.chroma.spring;
 
 import dev.langchain4j.store.embedding.chroma.ChromaApiVersion;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 import java.time.Duration;
 
+@Validated
 @ConfigurationProperties(prefix = ChromaEmbeddingStoreProperties.PREFIX)
 public class ChromaEmbeddingStoreProperties {
 

--- a/langchain4j-chroma-spring-boot4-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/langchain4j-chroma-spring-boot4-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.langchain4j.store.embedding.chroma.spring.ChromaEmbeddingStoreAutoConfiguration

--- a/langchain4j-chroma-spring-boot4-starter/src/test/java/ChromaEmbeddingStoreAutoConfigurationIT.java
+++ b/langchain4j-chroma-spring-boot4-starter/src/test/java/ChromaEmbeddingStoreAutoConfigurationIT.java
@@ -1,0 +1,45 @@
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.chroma.ChromaEmbeddingStore;
+import dev.langchain4j.store.embedding.chroma.spring.ChromaEmbeddingStoreAutoConfiguration;
+import dev.langchain4j.store.embedding.spring.EmbeddingStoreAutoConfigurationIT;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.testcontainers.chromadb.ChromaDBContainer;
+
+class ChromaEmbeddingStoreAutoConfigurationIT extends EmbeddingStoreAutoConfigurationIT {
+
+    static ChromaDBContainer chroma = new ChromaDBContainer("chromadb/chroma:0.5.0");
+
+    @BeforeAll
+    static void beforeAll() {
+        chroma.start();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        chroma.stop();
+    }
+
+    @Override
+    protected Class<?> autoConfigurationClass() {
+        return ChromaEmbeddingStoreAutoConfiguration.class;
+    }
+
+    @Override
+    protected Class<? extends EmbeddingStore<TextSegment>> embeddingStoreClass() {
+        return ChromaEmbeddingStore.class;
+    }
+
+    @Override
+    protected String[] properties() {
+        return new String[]{
+                "langchain4j.chroma.baseUrl=" + chroma.getEndpoint()
+        };
+    }
+
+    @Override
+    protected String dimensionPropertyKey() {
+        return "langchain4j.chroma.dimension";
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <module>langchain4j-elasticsearch-spring-boot-starter</module>
         <module>langchain4j-elasticsearch-spring-boot4-starter</module>
         <module>langchain4j-milvus-spring-boot-starter</module>
+        <module>langchain4j-chroma-spring-boot-starter</module>
         <module>langchain4j-milvus-spring-boot4-starter</module>
         <module>langchain4j-mistral-ai-spring-boot-starter</module>
         <module>langchain4j-mistral-ai-spring-boot4-starter</module>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <module>langchain4j-elasticsearch-spring-boot4-starter</module>
         <module>langchain4j-milvus-spring-boot-starter</module>
         <module>langchain4j-chroma-spring-boot-starter</module>
+        <module>langchain4j-chroma-spring-boot4-starter</module>
         <module>langchain4j-milvus-spring-boot4-starter</module>
         <module>langchain4j-mistral-ai-spring-boot-starter</module>
         <module>langchain4j-mistral-ai-spring-boot4-starter</module>


### PR DESCRIPTION
## Issue
Closes #2205

## Change
Adds Spring Boot 4 auto-configuration starter for `langchain4j-chroma`.
Follows the same pattern as existing Boot 4 starters (Milvus, Elasticsearch, etc.).
Complements the existing `langchain4j-chroma-spring-boot-starter` (Boot 3).

Includes:
- `ChromaEmbeddingStoreAutoConfiguration`
- `ChromaEmbeddingStoreProperties`
- `AutoConfiguration.imports` registration
- Integration test with Testcontainers (ChromaDBContainer)

## General checklist
- [X] There are no breaking changes
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo

## Checklist for adding new Spring Boot starter
- [X] I have added my new starter in the root `pom.xml`
- [X] I have added a `org.springframework.boot.autoconfigure.AutoConfiguration.imports` file
