### PR TITLE
Cancel StreamingHandle when Reactor Flux is cancelled

### DIFF
--- a/langchain4j-reactor/src/main/java/dev/langchain4j/reactor/TokenStreamToFluxAdapter.java
+++ b/langchain4j-reactor/src/main/java/dev/langchain4j/reactor/TokenStreamToFluxAdapter.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.reactor;
 
+import dev.langchain4j.model.chat.response.StreamingHandle;
 import dev.langchain4j.service.TokenStream;
 import dev.langchain4j.spi.services.TokenStreamAdapter;
 import reactor.core.publisher.Flux;
@@ -7,6 +8,11 @@ import reactor.core.publisher.Sinks;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class TokenStreamToFluxAdapter implements TokenStreamAdapter {
 
@@ -24,10 +30,41 @@ public class TokenStreamToFluxAdapter implements TokenStreamAdapter {
     @Override
     public Object adapt(TokenStream tokenStream) {
         Sinks.Many<String> sink = Sinks.many().unicast().onBackpressureBuffer();
-        tokenStream.onPartialResponse(sink::tryEmitNext)
+        AtomicBoolean cancelled = new AtomicBoolean();
+        AtomicReference<StreamingHandle> streamingHandleReference = new AtomicReference<>();
+        Set<StreamingHandle> streamingHandlesWithCancellationAttempts =
+                Collections.synchronizedSet(Collections.newSetFromMap(new IdentityHashMap<>()));
+
+        Flux<String> flux = sink.asFlux().doOnCancel(() -> {
+            cancelled.set(true);
+            cancel(streamingHandleReference.get(), streamingHandlesWithCancellationAttempts);
+        });
+
+        tokenStream.onStreamingHandle(streamingHandle -> {
+                    streamingHandleReference.set(streamingHandle);
+                    if (cancelled.get()) {
+                        cancel(streamingHandle, streamingHandlesWithCancellationAttempts);
+                    }
+                })
+                .onPartialResponse(sink::tryEmitNext)
                 .onCompleteResponse(ignored -> sink.tryEmitComplete())
                 .onError(sink::tryEmitError)
                 .start();
-        return sink.asFlux();
+        return flux;
+    }
+
+    private static void cancel(
+            StreamingHandle streamingHandle, Set<StreamingHandle> streamingHandlesWithCancellationAttempts) {
+        if (streamingHandle == null || streamingHandle.isCancelled()) {
+            return;
+        }
+        if (!streamingHandlesWithCancellationAttempts.add(streamingHandle)) {
+            return;
+        }
+        try {
+            streamingHandle.cancel();
+        } catch (RuntimeException ignored) {
+            // Some StreamingChatModel implementations expose non-cancellable handles.
+        }
     }
 }

--- a/langchain4j-reactor/src/main/java/dev/langchain4j/reactor/TokenStreamToFluxAdapter.java
+++ b/langchain4j-reactor/src/main/java/dev/langchain4j/reactor/TokenStreamToFluxAdapter.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.reactor;
 
+import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.model.chat.response.StreamingHandle;
 import dev.langchain4j.service.TokenStream;
 import dev.langchain4j.spi.services.TokenStreamAdapter;
 import reactor.core.publisher.Flux;
@@ -7,6 +9,8 @@ import reactor.core.publisher.Sinks;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class TokenStreamToFluxAdapter implements TokenStreamAdapter {
 
@@ -24,10 +28,35 @@ public class TokenStreamToFluxAdapter implements TokenStreamAdapter {
     @Override
     public Object adapt(TokenStream tokenStream) {
         Sinks.Many<String> sink = Sinks.many().unicast().onBackpressureBuffer();
-        tokenStream.onPartialResponse(sink::tryEmitNext)
+        AtomicBoolean cancelled = new AtomicBoolean();
+        AtomicReference<StreamingHandle> streamingHandleReference = new AtomicReference<>();
+
+        Flux<String> flux = sink.asFlux().doOnCancel(() -> {
+            cancelled.set(true);
+            cancel(streamingHandleReference.getAndSet(null));
+        });
+
+        tokenStream.onStreamingHandle(streamingHandle -> {
+                    streamingHandleReference.set(streamingHandle);
+                    if (cancelled.get()) {
+                        cancel(streamingHandleReference.getAndSet(null));
+                    }
+                })
+                .onPartialResponse(sink::tryEmitNext)
                 .onCompleteResponse(ignored -> sink.tryEmitComplete())
                 .onError(sink::tryEmitError)
                 .start();
-        return sink.asFlux();
+        return flux;
+    }
+
+    private static void cancel(StreamingHandle streamingHandle) {
+        if (streamingHandle == null || streamingHandle.isCancelled()) {
+            return;
+        }
+        try {
+            streamingHandle.cancel();
+        } catch (UnsupportedFeatureException ignored) {
+            // Cancellation is best-effort.
+        }
     }
 }

--- a/langchain4j-reactor/src/test/java/dev/langchain4j/reactor/AiServiceWithFluxTest.java
+++ b/langchain4j-reactor/src/test/java/dev/langchain4j/reactor/AiServiceWithFluxTest.java
@@ -1,19 +1,33 @@
 package dev.langchain4j.reactor;
 
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.guardrail.OutputGuardrail;
+import dev.langchain4j.guardrail.OutputGuardrailResult;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.mock.StreamingChatModelMock;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.PartialResponse;
+import dev.langchain4j.model.chat.response.PartialResponseContext;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.chat.response.StreamingHandle;
 import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.guardrail.OutputGuardrails;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class AiServiceWithFluxTest {
 
     interface Assistant {
 
         Flux<String> stream(String userMessage);
+
+        @OutputGuardrails(OKGuardrail.class)
+        Flux<String> streamWithOutputGuardrails(String userMessage);
     }
 
     @Test
@@ -35,5 +49,81 @@ public class AiServiceWithFluxTest {
         StepVerifier.create(flux)
                 .expectNextSequence(tokens)
                 .verifyComplete();
+    }
+
+    @Test
+    void should_stream_with_output_guardrails() {
+
+        // given
+        List<String> tokens = List.of("H", "e", "l", "l", "o");
+
+        StreamingChatModel model = StreamingChatModelMock.thatAlwaysStreams(tokens);
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .streamingChatModel(model)
+                .build();
+
+        // when
+        Flux<String> flux = assistant.streamWithOutputGuardrails("Hi");
+
+        // then
+        StepVerifier.create(flux)
+                .expectNextSequence(tokens)
+                .verifyComplete();
+    }
+
+    @Test
+    void should_cancel_streaming_handle_when_flux_subscription_is_cancelled() {
+
+        // given
+        CancellableStreamingChatModel model = new CancellableStreamingChatModel();
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .streamingChatModel(model)
+                .build();
+
+        // when
+        Flux<String> flux = assistant.stream("Hi");
+
+        // then
+        StepVerifier.create(flux)
+                .expectNext("hello")
+                .thenCancel()
+                .verify();
+
+        assertThat(model.streamingHandle.isCancelled()).isTrue();
+    }
+
+    public static class OKGuardrail implements OutputGuardrail {
+
+        @Override
+        public OutputGuardrailResult validate(AiMessage responseFromLLM) {
+            return success();
+        }
+    }
+
+    private static class CancellableStreamingChatModel implements StreamingChatModel {
+
+        private final TestStreamingHandle streamingHandle = new TestStreamingHandle();
+
+        @Override
+        public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+            handler.onPartialResponse(new PartialResponse("hello"), new PartialResponseContext(streamingHandle));
+        }
+    }
+
+    private static class TestStreamingHandle implements StreamingHandle {
+
+        private boolean cancelled;
+
+        @Override
+        public void cancel() {
+            cancelled = true;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return cancelled;
+        }
     }
 }

--- a/langchain4j-reactor/src/test/java/dev/langchain4j/reactor/AiServiceWithFluxTest.java
+++ b/langchain4j-reactor/src/test/java/dev/langchain4j/reactor/AiServiceWithFluxTest.java
@@ -2,12 +2,19 @@ package dev.langchain4j.reactor;
 
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.mock.StreamingChatModelMock;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.PartialResponse;
+import dev.langchain4j.model.chat.response.PartialResponseContext;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.chat.response.StreamingHandle;
 import dev.langchain4j.service.AiServices;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class AiServiceWithFluxTest {
 
@@ -35,5 +42,56 @@ public class AiServiceWithFluxTest {
         StepVerifier.create(flux)
                 .expectNextSequence(tokens)
                 .verifyComplete();
+    }
+
+    @Test
+    void should_cancel_streaming_handle_received_after_flux_subscription_is_cancelled() {
+
+        // given
+        LateResponseStreamingChatModel model = new LateResponseStreamingChatModel();
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .streamingChatModel(model)
+                .build();
+
+        // when
+        Flux<String> flux = assistant.stream("Hi");
+
+        // then
+        StepVerifier.create(flux).thenCancel().verify();
+
+        model.respond();
+
+        assertThat(model.streamingHandle.isCancelled()).isTrue();
+    }
+
+    private static class LateResponseStreamingChatModel implements StreamingChatModel {
+
+        private final TestStreamingHandle streamingHandle = new TestStreamingHandle();
+        private StreamingChatResponseHandler handler;
+
+        @Override
+        public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+            this.handler = handler;
+        }
+
+        void respond() {
+            handler.onPartialResponse(new PartialResponse("hello"), new PartialResponseContext(streamingHandle));
+        }
+    }
+
+    private static class TestStreamingHandle implements StreamingHandle {
+
+        private boolean cancelled;
+
+        @Override
+        public void cancel() {
+            cancelled = true;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return cancelled;
+        }
     }
 }

--- a/langchain4j-reactor/src/test/java/dev/langchain4j/reactor/TokenStreamToFluxAdapterTest.java
+++ b/langchain4j-reactor/src/test/java/dev/langchain4j/reactor/TokenStreamToFluxAdapterTest.java
@@ -1,9 +1,18 @@
 package dev.langchain4j.reactor;
 
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingHandle;
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.service.TokenStream;
+import dev.langchain4j.service.tool.ToolExecution;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
 
 import java.lang.reflect.Type;
+import java.util.List;
+import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,11 +38,193 @@ class TokenStreamToFluxAdapterTest {
         assertThat(adapter.canAdaptTokenStreamTo(getReturnTypeOfMethod("fluxOfObject"))).isFalse();
     }
 
+    @Test
+    void should_cancel_streaming_handle_when_flux_subscription_is_cancelled() {
+
+        TestTokenStream tokenStream = new TestTokenStream();
+
+        @SuppressWarnings("unchecked")
+        Flux<String> flux = (Flux<String>) new TokenStreamToFluxAdapter().adapt(tokenStream);
+
+        tokenStream.emitStreamingHandle();
+        tokenStream.emitPartialResponse("hello");
+
+        StepVerifier.create(flux)
+                .expectNext("hello")
+                .thenCancel()
+                .verify();
+
+        assertThat(tokenStream.streamingHandle.isCancelled()).isTrue();
+        assertThat(tokenStream.streamingHandle.cancellationAttempts()).isOne();
+
+        tokenStream.emitStreamingHandle();
+
+        assertThat(tokenStream.streamingHandle.cancellationAttempts()).isOne();
+    }
+
+    @Test
+    void should_cancel_streaming_handle_when_handle_is_received_after_flux_subscription_is_cancelled() {
+
+        TestTokenStream tokenStream = new TestTokenStream();
+
+        @SuppressWarnings("unchecked")
+        Flux<String> flux = (Flux<String>) new TokenStreamToFluxAdapter().adapt(tokenStream);
+
+        StepVerifier.create(flux)
+                .thenCancel()
+                .verify();
+
+        tokenStream.emitStreamingHandle();
+
+        assertThat(tokenStream.streamingHandle.isCancelled()).isTrue();
+    }
+
+    @Test
+    void should_not_cancel_streaming_handle_when_flux_completes_normally() {
+
+        TestTokenStream tokenStream = new TestTokenStream();
+
+        @SuppressWarnings("unchecked")
+        Flux<String> flux = (Flux<String>) new TokenStreamToFluxAdapter().adapt(tokenStream);
+
+        tokenStream.emitStreamingHandle();
+        tokenStream.emitPartialResponse("hello");
+        tokenStream.emitCompleteResponse();
+
+        StepVerifier.create(flux)
+                .expectNext("hello")
+                .verifyComplete();
+
+        assertThat(tokenStream.streamingHandle.isCancelled()).isFalse();
+        assertThat(tokenStream.streamingHandle.cancellationAttempts()).isZero();
+    }
+
+    @Test
+    void should_ignore_runtime_exception_when_cancelling_streaming_handle() {
+
+        ThrowingStreamingHandle streamingHandle = new ThrowingStreamingHandle();
+        TestTokenStream tokenStream = new TestTokenStream(streamingHandle);
+
+        @SuppressWarnings("unchecked")
+        Flux<String> flux = (Flux<String>) new TokenStreamToFluxAdapter().adapt(tokenStream);
+
+        tokenStream.emitStreamingHandle();
+        tokenStream.emitPartialResponse("hello");
+
+        StepVerifier.create(flux)
+                .expectNext("hello")
+                .thenCancel()
+                .verify();
+
+        assertThat(streamingHandle.cancellationAttempts()).isOne();
+    }
+
     private static Type getReturnTypeOfMethod(String methodName) {
         try {
             return Assistant.class.getDeclaredMethod(methodName).getGenericReturnType();
         } catch (NoSuchMethodException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    private static class TestTokenStream implements TokenStream {
+
+        private final TestStreamingHandle streamingHandle;
+        private Consumer<String> partialResponseHandler;
+        private Consumer<StreamingHandle> streamingHandleHandler;
+        private Consumer<ChatResponse> completionHandler;
+
+        TestTokenStream() {
+            this(new TestStreamingHandle());
+        }
+
+        TestTokenStream(TestStreamingHandle streamingHandle) {
+            this.streamingHandle = streamingHandle;
+        }
+
+        @Override
+        public TokenStream onPartialResponse(Consumer<String> partialResponseHandler) {
+            this.partialResponseHandler = partialResponseHandler;
+            return this;
+        }
+
+        @Override
+        public TokenStream onStreamingHandle(Consumer<StreamingHandle> streamingHandleHandler) {
+            this.streamingHandleHandler = streamingHandleHandler;
+            return this;
+        }
+
+        @Override
+        public TokenStream onRetrieved(Consumer<List<Content>> contentHandler) {
+            return this;
+        }
+
+        @Override
+        public TokenStream onToolExecuted(Consumer<ToolExecution> toolExecutionHandler) {
+            return this;
+        }
+
+        @Override
+        public TokenStream onCompleteResponse(Consumer<ChatResponse> completionHandler) {
+            this.completionHandler = completionHandler;
+            return this;
+        }
+
+        @Override
+        public TokenStream onError(Consumer<Throwable> errorHandler) {
+            return this;
+        }
+
+        @Override
+        public TokenStream ignoreErrors() {
+            return this;
+        }
+
+        @Override
+        public void start() {}
+
+        void emitStreamingHandle() {
+            streamingHandleHandler.accept(streamingHandle);
+        }
+
+        void emitPartialResponse(String partialResponse) {
+            partialResponseHandler.accept(partialResponse);
+        }
+
+        void emitCompleteResponse() {
+            completionHandler.accept(ChatResponse.builder()
+                    .aiMessage(AiMessage.from("hello"))
+                    .build());
+        }
+    }
+
+    private static class TestStreamingHandle implements StreamingHandle {
+
+        private boolean cancelled;
+        private int cancellationAttempts;
+
+        @Override
+        public void cancel() {
+            cancellationAttempts++;
+            cancelled = true;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return cancelled;
+        }
+
+        int cancellationAttempts() {
+            return cancellationAttempts;
+        }
+    }
+
+    private static class ThrowingStreamingHandle extends TestStreamingHandle {
+
+        @Override
+        public void cancel() {
+            super.cancel();
+            throw new RuntimeException("cancel failed");
         }
     }
 }


### PR DESCRIPTION
## Issue
Fixes langchain4j/langchain4j#5275

Depends on langchain4j/langchain4j#5303.

## Change
Propagates Reactor `Flux<String>` cancellation to the underlying `StreamingHandle`, including when the handle arrives after the subscription has already been cancelled. Unsupported cancellation remains best-effort.

## Verification
- [x] Regression test fails without the adapter change
- [x] `./mvnw -pl langchain4j-reactor test`
- [x] `git diff --check`
