### PR TITLE
Added returnThinking and sendThinking properties to Gemini Spring Boot starters

### DIFF
--- a/langchain4j-google-ai-gemini-spring-boot-starter/src/main/java/dev/langchain4j/googleaigemini/spring/AutoConfig.java
+++ b/langchain4j-google-ai-gemini-spring-boot-starter/src/main/java/dev/langchain4j/googleaigemini/spring/AutoConfig.java
@@ -41,6 +41,8 @@ class AutoConfig {
                 .stopSequences(chatModelProperties.stopSequences())
                 .allowCodeExecution(chatModelProperties.allowCodeExecution())
                 .includeCodeExecutionOutput(chatModelProperties.includeCodeExecutionOutput())
+                .returnThinking(chatModelProperties.returnThinking())
+                .sendThinking(chatModelProperties.sendThinking())
                 .logRequestsAndResponses(chatModelProperties.logRequestsAndResponses())
                 .listeners(listeners.orderedStream().toList());
 
@@ -84,6 +86,8 @@ class AutoConfig {
                 .stopSequences(chatModelProperties.stopSequences())
                 .allowCodeExecution(chatModelProperties.allowCodeExecution())
                 .includeCodeExecutionOutput(chatModelProperties.includeCodeExecutionOutput())
+                .returnThinking(chatModelProperties.returnThinking())
+                .sendThinking(chatModelProperties.sendThinking())
                 .logRequestsAndResponses(chatModelProperties.logRequestsAndResponses())
                 .listeners(listeners.orderedStream().toList());
 

--- a/langchain4j-google-ai-gemini-spring-boot-starter/src/main/java/dev/langchain4j/googleaigemini/spring/ChatModelProperties.java
+++ b/langchain4j-google-ai-gemini-spring-boot-starter/src/main/java/dev/langchain4j/googleaigemini/spring/ChatModelProperties.java
@@ -17,6 +17,8 @@ public record ChatModelProperties(
         Integer maxOutputTokens,
         Boolean allowCodeExecution,
         Boolean includeCodeExecutionOutput,
+		Boolean returnThinking,
+		Boolean sendThinking,
         Boolean logRequestsAndResponses,
         Integer maxRetries,
         Duration timeout,

--- a/langchain4j-google-ai-gemini-spring-boot4-starter/src/main/java/dev/langchain4j/googleaigemini/spring/GoogleAiGeminiAutoConfiguration.java
+++ b/langchain4j-google-ai-gemini-spring-boot4-starter/src/main/java/dev/langchain4j/googleaigemini/spring/GoogleAiGeminiAutoConfiguration.java
@@ -41,6 +41,8 @@ class GoogleAiGeminiAutoConfiguration {
                 .stopSequences(chatModelProperties.stopSequences())
                 .allowCodeExecution(chatModelProperties.allowCodeExecution())
                 .includeCodeExecutionOutput(chatModelProperties.includeCodeExecutionOutput())
+                .returnThinking(chatModelProperties.returnThinking())
+                .sendThinking(chatModelProperties.sendThinking())
                 .logRequestsAndResponses(chatModelProperties.logRequestsAndResponses())
                 .listeners(listeners.orderedStream().toList());
 
@@ -84,6 +86,8 @@ class GoogleAiGeminiAutoConfiguration {
                 .stopSequences(chatModelProperties.stopSequences())
                 .allowCodeExecution(chatModelProperties.allowCodeExecution())
                 .includeCodeExecutionOutput(chatModelProperties.includeCodeExecutionOutput())
+                .returnThinking(chatModelProperties.returnThinking())
+                .sendThinking(chatModelProperties.sendThinking())
                 .logRequestsAndResponses(chatModelProperties.logRequestsAndResponses())
                 .listeners(listeners.orderedStream().toList());
 

--- a/langchain4j-google-ai-gemini-spring-boot4-starter/src/main/java/dev/langchain4j/googleaigemini/spring/GoogleAiGeminiChatModelProperties.java
+++ b/langchain4j-google-ai-gemini-spring-boot4-starter/src/main/java/dev/langchain4j/googleaigemini/spring/GoogleAiGeminiChatModelProperties.java
@@ -17,6 +17,8 @@ public record GoogleAiGeminiChatModelProperties(
         Integer maxOutputTokens,
         Boolean allowCodeExecution,
         Boolean includeCodeExecutionOutput,
+        Boolean returnThinking,
+        Boolean sendThinking,
         Boolean logRequestsAndResponses,
         Integer maxRetries,
         Duration timeout,


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes langchain4j/langchain4j#5621

## Change
<!-- Please describe the changes you made. -->
This adds returnThinking and sendThinking configuration properties to the Gemini ChatModel and StreamingChatModel auto-configurations for both spring-boot and spring-boot4 starters.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)


## Checklist for adding new Spring Boot starter
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new starter in the root `pom.xml`
- [ ] I have added a `org.springframework.boot.autoconfigure.AutoConfiguration.imports` file in the `langchain4j-{integration}-spring-boot-starter/src/main/resources/META-INF/spring/` directory
