### PR TITLE
Add separate logging properties for requests/responses to Gemini starters

### DIFF
--- a/langchain4j-google-ai-gemini-spring-boot-starter/src/main/java/dev/langchain4j/googleaigemini/spring/AutoConfig.java
+++ b/langchain4j-google-ai-gemini-spring-boot-starter/src/main/java/dev/langchain4j/googleaigemini/spring/AutoConfig.java
@@ -44,6 +44,8 @@ class AutoConfig {
                 .returnThinking(chatModelProperties.returnThinking())
                 .sendThinking(chatModelProperties.sendThinking())
                 .logRequestsAndResponses(chatModelProperties.logRequestsAndResponses())
+                .logRequests(chatModelProperties.logRequests())
+                .logResponses(chatModelProperties.logResponses())
                 .listeners(listeners.orderedStream().toList());
 
         if (chatModelProperties.safetySetting() != null && !chatModelProperties.safetySetting().isEmpty()) {
@@ -89,6 +91,8 @@ class AutoConfig {
                 .returnThinking(chatModelProperties.returnThinking())
                 .sendThinking(chatModelProperties.sendThinking())
                 .logRequestsAndResponses(chatModelProperties.logRequestsAndResponses())
+                .logRequests(chatModelProperties.logRequests())
+                .logResponses(chatModelProperties.logResponses())
                 .listeners(listeners.orderedStream().toList());
 
 
@@ -126,6 +130,8 @@ class AutoConfig {
                 .outputDimensionality(embeddingModelProperties.outputDimensionality())
                 .timeout(embeddingModelProperties.timeout())
                 .logRequestsAndResponses(embeddingModelProperties.logRequestsAndResponses())
+                .logRequests(embeddingModelProperties.logRequests())
+                .logResponses(embeddingModelProperties.logResponses())
                 .build();
     }
 

--- a/langchain4j-google-ai-gemini-spring-boot-starter/src/main/java/dev/langchain4j/googleaigemini/spring/ChatModelProperties.java
+++ b/langchain4j-google-ai-gemini-spring-boot-starter/src/main/java/dev/langchain4j/googleaigemini/spring/ChatModelProperties.java
@@ -20,6 +20,8 @@ public record ChatModelProperties(
 		Boolean returnThinking,
 		Boolean sendThinking,
         Boolean logRequestsAndResponses,
+        Boolean logRequests,
+        Boolean logResponses,
         Integer maxRetries,
         Duration timeout,
         List<String> stopSequences,

--- a/langchain4j-google-ai-gemini-spring-boot-starter/src/main/java/dev/langchain4j/googleaigemini/spring/EmbeddingModelProperties.java
+++ b/langchain4j-google-ai-gemini-spring-boot-starter/src/main/java/dev/langchain4j/googleaigemini/spring/EmbeddingModelProperties.java
@@ -9,6 +9,8 @@ public record EmbeddingModelProperties(
         String modelName,
         String titleMetadataKey,
         Boolean logRequestsAndResponses,
+        Boolean logRequests,
+        Boolean logResponses,
         Integer maxRetries,
         Integer outputDimensionality,
         TaskType taskType,

--- a/langchain4j-google-ai-gemini-spring-boot4-starter/src/main/java/dev/langchain4j/googleaigemini/spring/GoogleAiGeminiAutoConfiguration.java
+++ b/langchain4j-google-ai-gemini-spring-boot4-starter/src/main/java/dev/langchain4j/googleaigemini/spring/GoogleAiGeminiAutoConfiguration.java
@@ -44,6 +44,8 @@ class GoogleAiGeminiAutoConfiguration {
                 .returnThinking(chatModelProperties.returnThinking())
                 .sendThinking(chatModelProperties.sendThinking())
                 .logRequestsAndResponses(chatModelProperties.logRequestsAndResponses())
+                .logRequests(chatModelProperties.logRequests())
+                .logResponses(chatModelProperties.logResponses())
                 .listeners(listeners.orderedStream().toList());
 
         if (chatModelProperties.safetySetting() != null && !chatModelProperties.safetySetting().isEmpty()) {
@@ -89,6 +91,8 @@ class GoogleAiGeminiAutoConfiguration {
                 .returnThinking(chatModelProperties.returnThinking())
                 .sendThinking(chatModelProperties.sendThinking())
                 .logRequestsAndResponses(chatModelProperties.logRequestsAndResponses())
+                .logRequests(chatModelProperties.logRequests())
+                .logResponses(chatModelProperties.logResponses())
                 .listeners(listeners.orderedStream().toList());
 
 
@@ -126,6 +130,8 @@ class GoogleAiGeminiAutoConfiguration {
                 .outputDimensionality(embeddingModelProperties.outputDimensionality())
                 .timeout(embeddingModelProperties.timeout())
                 .logRequestsAndResponses(embeddingModelProperties.logRequestsAndResponses())
+                .logRequests(embeddingModelProperties.logRequests())
+                .logResponses(embeddingModelProperties.logResponses())
                 .build();
     }
 

--- a/langchain4j-google-ai-gemini-spring-boot4-starter/src/main/java/dev/langchain4j/googleaigemini/spring/GoogleAiGeminiChatModelProperties.java
+++ b/langchain4j-google-ai-gemini-spring-boot4-starter/src/main/java/dev/langchain4j/googleaigemini/spring/GoogleAiGeminiChatModelProperties.java
@@ -20,6 +20,8 @@ public record GoogleAiGeminiChatModelProperties(
         Boolean returnThinking,
         Boolean sendThinking,
         Boolean logRequestsAndResponses,
+        Boolean logRequests,
+        Boolean logResponses,
         Integer maxRetries,
         Duration timeout,
         List<String> stopSequences,

--- a/langchain4j-google-ai-gemini-spring-boot4-starter/src/main/java/dev/langchain4j/googleaigemini/spring/GoogleAiGeminiEmbeddingModelProperties.java
+++ b/langchain4j-google-ai-gemini-spring-boot4-starter/src/main/java/dev/langchain4j/googleaigemini/spring/GoogleAiGeminiEmbeddingModelProperties.java
@@ -9,6 +9,8 @@ public record GoogleAiGeminiEmbeddingModelProperties(
         String modelName,
         String titleMetadataKey,
         Boolean logRequestsAndResponses,
+        Boolean logRequests,
+        Boolean logResponses,
         Integer maxRetries,
         Integer outputDimensionality,
         TaskType taskType,


### PR DESCRIPTION
## Change

This adds separate properties to log requests and responses to the Gemini spring boot 3 and 4 starters, similar to the properties in other starters.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)


## Checklist for adding new Spring Boot starter
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new starter in the root `pom.xml`
- [ ] I have added a `org.springframework.boot.autoconfigure.AutoConfiguration.imports` file in the `langchain4j-{integration}-spring-boot-starter/src/main/resources/META-INF/spring/` directory
