### PR TITLE
Disable Apache HttpClient automatic retries in SpringRestClient

### DIFF
--- a/langchain4j-http-client-spring-boot4-restclient/pom.xml
+++ b/langchain4j-http-client-spring-boot4-restclient/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <scope>test</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/langchain4j-http-client-spring-boot4-restclient/src/main/java/dev/langchain4j/http/client/spring/restclient/SpringRestClient.java
+++ b/langchain4j-http-client-spring-boot4-restclient/src/main/java/dev/langchain4j/http/client/spring/restclient/SpringRestClient.java
@@ -9,6 +9,8 @@ import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import dev.langchain4j.http.client.sse.ServerSentEventListener;
 import dev.langchain4j.http.client.sse.ServerSentEventParser;
 import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.springframework.boot.http.client.HttpComponentsClientHttpRequestFactoryBuilder;
 import org.springframework.boot.http.client.HttpClientSettings;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.task.AsyncTaskExecutor;
@@ -46,7 +48,11 @@ public class SpringRestClient implements HttpClient {
         if (builder.readTimeout() != null) {
             settings = settings.withReadTimeout(builder.readTimeout());
         }
-        ClientHttpRequestFactory clientHttpRequestFactory = ClientHttpRequestFactoryBuilder.detect().build(settings);
+        ClientHttpRequestFactoryBuilder<?> requestFactoryBuilder = ClientHttpRequestFactoryBuilder.detect();
+        if (requestFactoryBuilder instanceof HttpComponentsClientHttpRequestFactoryBuilder httpComponentsBuilder) {
+            requestFactoryBuilder = httpComponentsBuilder.withHttpClientCustomizer(HttpClientBuilder::disableAutomaticRetries);
+        }
+        ClientHttpRequestFactory clientHttpRequestFactory = requestFactoryBuilder.build(settings);
 
         this.delegate = restClientBuilder
                 .requestFactory(clientHttpRequestFactory)

--- a/langchain4j-http-client-spring-boot4-restclient/src/test/java/dev/langchain4j/http/client/spring/restclient/SpringRestClientApacheRetriesIT.java
+++ b/langchain4j-http-client-spring-boot4-restclient/src/test/java/dev/langchain4j/http/client/spring/restclient/SpringRestClientApacheRetriesIT.java
@@ -1,0 +1,40 @@
+package dev.langchain4j.http.client.spring.restclient;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.http.client.HttpMethod;
+import dev.langchain4j.http.client.HttpRequest;
+import org.junit.jupiter.api.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@WireMockTest
+class SpringRestClientApacheRetriesIT {
+
+    @Test
+    void should_not_retry_when_apache_httpclient5_is_on_classpath(WireMockRuntimeInfo wmRuntimeInfo) {
+        String path = "/apache-retries";
+        wmRuntimeInfo.getWireMock().register(
+                get(path).willReturn(aResponse().withStatus(503).withBody("unavailable"))
+        );
+
+        var client = SpringRestClient.builder().build();
+        HttpRequest request = HttpRequest.builder()
+                .method(HttpMethod.GET)
+                .url(wmRuntimeInfo.getHttpBaseUrl() + path)
+                .build();
+
+        assertThatThrownBy(() -> client.execute(request))
+                .isInstanceOf(HttpException.class)
+                .extracting(ex -> ((HttpException) ex).statusCode())
+                .isEqualTo(503);
+
+        verify(1, getRequestedFor(urlEqualTo(path)));
+    }
+}

--- a/langchain4j-http-client-spring-restclient/pom.xml
+++ b/langchain4j-http-client-spring-restclient/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <scope>test</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/langchain4j-http-client-spring-restclient/src/main/java/dev/langchain4j/http/client/spring/restclient/SpringRestClient.java
+++ b/langchain4j-http-client-spring-restclient/src/main/java/dev/langchain4j/http/client/spring/restclient/SpringRestClient.java
@@ -9,6 +9,8 @@ import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import dev.langchain4j.http.client.sse.ServerSentEventListener;
 import dev.langchain4j.http.client.sse.ServerSentEventParser;
 import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.springframework.boot.http.client.HttpComponentsClientHttpRequestFactoryBuilder;
 import org.springframework.boot.http.client.ClientHttpRequestFactorySettings;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.task.AsyncTaskExecutor;
@@ -43,7 +45,11 @@ public class SpringRestClient implements HttpClient {
         if (builder.readTimeout() != null) {
             settings = settings.withReadTimeout(builder.readTimeout());
         }
-        ClientHttpRequestFactory clientHttpRequestFactory = ClientHttpRequestFactoryBuilder.detect().build(settings);
+        ClientHttpRequestFactoryBuilder<?> requestFactoryBuilder = ClientHttpRequestFactoryBuilder.detect();
+        if (requestFactoryBuilder instanceof HttpComponentsClientHttpRequestFactoryBuilder httpComponentsBuilder) {
+            requestFactoryBuilder = httpComponentsBuilder.withHttpClientCustomizer(HttpClientBuilder::disableAutomaticRetries);
+        }
+        ClientHttpRequestFactory clientHttpRequestFactory = requestFactoryBuilder.build(settings);
 
         this.delegate = restClientBuilder
                 .requestFactory(clientHttpRequestFactory)

--- a/langchain4j-http-client-spring-restclient/src/test/java/dev/langchain4j/http/client/spring/restclient/SpringRestClientApacheRetriesIT.java
+++ b/langchain4j-http-client-spring-restclient/src/test/java/dev/langchain4j/http/client/spring/restclient/SpringRestClientApacheRetriesIT.java
@@ -1,0 +1,40 @@
+package dev.langchain4j.http.client.spring.restclient;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.http.client.HttpMethod;
+import dev.langchain4j.http.client.HttpRequest;
+import org.junit.jupiter.api.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@WireMockTest
+class SpringRestClientApacheRetriesIT {
+
+    @Test
+    void should_not_retry_when_apache_httpclient5_is_on_classpath(WireMockRuntimeInfo wmRuntimeInfo) {
+        String path = "/apache-retries";
+        wmRuntimeInfo.getWireMock().register(
+                get(path).willReturn(aResponse().withStatus(503).withBody("unavailable"))
+        );
+
+        var client = SpringRestClient.builder().build();
+        HttpRequest request = HttpRequest.builder()
+                .method(HttpMethod.GET)
+                .url(wmRuntimeInfo.getHttpBaseUrl() + path)
+                .build();
+
+        assertThatThrownBy(() -> client.execute(request))
+                .isInstanceOf(HttpException.class)
+                .extracting(ex -> ((HttpException) ex).statusCode())
+                .isEqualTo(503);
+
+        verify(1, getRequestedFor(urlEqualTo(path)));
+    }
+}


### PR DESCRIPTION
## Change
When Apache HttpClient 5 is on the classpath, `SpringRestClient` rebuilt the request factory via `ClientHttpRequestFactoryBuilder.detect()` without disabling HttpClient's automatic retries. That made `max-retries=0` ineffective for Spring Boot starters.

This disables transport-level automatic retries for the Apache factory (Boot 3 + Boot 4 modules) so LangChain4j remains the single owner of retry behavior.

## Fixes
https://github.com/langchain4j/langchain4j/issues/5789

## Test
- `SpringRestClientApacheRetriesIT`: WireMock returns 503; assert exactly one request and `HttpException(503)`.