### PR TITLE
Restore OpenAI Spring proxy properties

### DIFF
--- a/langchain4j-http-client-spring-boot4-restclient/src/main/java/dev/langchain4j/http/client/spring/restclient/SpringRestClient.java
+++ b/langchain4j-http-client-spring-boot4-restclient/src/main/java/dev/langchain4j/http/client/spring/restclient/SpringRestClient.java
@@ -8,8 +8,9 @@ import dev.langchain4j.http.client.HttpRequest;
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import dev.langchain4j.http.client.sse.ServerSentEventListener;
 import dev.langchain4j.http.client.sse.ServerSentEventParser;
-import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder;
+import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder;
 import org.springframework.boot.http.client.HttpComponentsClientHttpRequestFactoryBuilder;
 import org.springframework.boot.http.client.HttpClientSettings;
 import org.springframework.core.io.ByteArrayResource;
@@ -24,6 +25,8 @@ import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 
 import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.net.SocketTimeoutException;
 import java.util.List;
 import java.util.Map;
@@ -50,7 +53,10 @@ public class SpringRestClient implements HttpClient {
         }
         ClientHttpRequestFactoryBuilder<?> requestFactoryBuilder = ClientHttpRequestFactoryBuilder.detect();
         if (requestFactoryBuilder instanceof HttpComponentsClientHttpRequestFactoryBuilder httpComponentsBuilder) {
-            requestFactoryBuilder = httpComponentsBuilder.withHttpClientCustomizer(HttpClientBuilder::disableAutomaticRetries);
+            requestFactoryBuilder = httpComponentsBuilder.withHttpClientCustomizer(httpClientBuilder -> {
+                httpClientBuilder.disableAutomaticRetries();
+                applyProxy(httpClientBuilder, builder.proxy());
+            });
         }
         ClientHttpRequestFactory clientHttpRequestFactory = requestFactoryBuilder.build(settings);
 
@@ -76,6 +82,22 @@ public class SpringRestClient implements HttpClient {
 
     public static SpringRestClientBuilder builder() {
         return new SpringRestClientBuilder();
+    }
+
+    private static void applyProxy(HttpClientBuilder httpClientBuilder, Proxy proxy) {
+        if (proxy == null || proxy.type() == Proxy.Type.DIRECT) {
+            return;
+        }
+
+        if (proxy.type() != Proxy.Type.HTTP) {
+            throw new IllegalArgumentException("Only HTTP proxies are supported");
+        }
+
+        if (!(proxy.address() instanceof InetSocketAddress proxyAddress)) {
+            throw new IllegalArgumentException("Proxy address must be an InetSocketAddress");
+        }
+
+        httpClientBuilder.setProxy(new HttpHost(proxyAddress.getHostString(), proxyAddress.getPort()));
     }
 
     @Override

--- a/langchain4j-http-client-spring-boot4-restclient/src/main/java/dev/langchain4j/http/client/spring/restclient/SpringRestClientBuilder.java
+++ b/langchain4j-http-client-spring-boot4-restclient/src/main/java/dev/langchain4j/http/client/spring/restclient/SpringRestClientBuilder.java
@@ -4,6 +4,7 @@ import dev.langchain4j.http.client.HttpClientBuilder;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.web.client.RestClient;
 
+import java.net.Proxy;
 import java.time.Duration;
 
 public class SpringRestClientBuilder implements HttpClientBuilder {
@@ -13,6 +14,7 @@ public class SpringRestClientBuilder implements HttpClientBuilder {
     private Boolean createDefaultStreamingRequestExecutor = true;
     private Duration connectTimeout;
     private Duration readTimeout;
+    private Proxy proxy;
 
     public RestClient.Builder restClientBuilder() {
         return restClientBuilder;
@@ -60,6 +62,15 @@ public class SpringRestClientBuilder implements HttpClientBuilder {
     @Override
     public SpringRestClientBuilder readTimeout(Duration readTimeout) {
         this.readTimeout = readTimeout;
+        return this;
+    }
+
+    public Proxy proxy() {
+        return proxy;
+    }
+
+    public SpringRestClientBuilder proxy(Proxy proxy) {
+        this.proxy = proxy;
         return this;
     }
 

--- a/langchain4j-http-client-spring-boot4-restclient/src/test/java/dev/langchain4j/http/client/spring/restclient/SpringRestClientProxyIT.java
+++ b/langchain4j-http-client-spring-boot4-restclient/src/test/java/dev/langchain4j/http/client/spring/restclient/SpringRestClientProxyIT.java
@@ -1,0 +1,66 @@
+package dev.langchain4j.http.client.spring.restclient;
+
+import com.sun.net.httpserver.HttpServer;
+import dev.langchain4j.http.client.HttpMethod;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SpringRestClientProxyIT {
+
+    @Test
+    void should_route_requests_through_configured_http_proxy() throws IOException {
+        AtomicReference<String> requestedUri = new AtomicReference<>();
+
+        HttpServer proxyServer = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        proxyServer.createContext("/", exchange -> {
+            requestedUri.set(exchange.getRequestURI().toString());
+
+            byte[] body = "proxied".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream responseBody = exchange.getResponseBody()) {
+                responseBody.write(body);
+            }
+        });
+        proxyServer.start();
+
+        try {
+            int proxyPort = proxyServer.getAddress().getPort();
+            SpringRestClient client = SpringRestClient.builder()
+                    .proxy(new Proxy(Proxy.Type.HTTP, new InetSocketAddress("localhost", proxyPort)))
+                    .createDefaultStreamingRequestExecutor(false)
+                    .build();
+            HttpRequest request = HttpRequest.builder()
+                    .method(HttpMethod.GET)
+                    .url("http://example.com/proxy-test")
+                    .build();
+
+            SuccessfulHttpResponse response = client.execute(request);
+
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.body()).isEqualTo("proxied");
+            assertThat(requestedUri.get()).contains("proxy-test");
+        } finally {
+            proxyServer.stop(0);
+        }
+    }
+
+    @Test
+    void should_reject_non_http_proxy() {
+        assertThatThrownBy(() -> SpringRestClient.builder()
+                .proxy(new Proxy(Proxy.Type.SOCKS, new InetSocketAddress("localhost", 1080)))
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Only HTTP proxies are supported");
+    }
+}

--- a/langchain4j-http-client-spring-restclient/src/main/java/dev/langchain4j/http/client/spring/restclient/SpringRestClient.java
+++ b/langchain4j-http-client-spring-restclient/src/main/java/dev/langchain4j/http/client/spring/restclient/SpringRestClient.java
@@ -8,10 +8,11 @@ import dev.langchain4j.http.client.HttpRequest;
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import dev.langchain4j.http.client.sse.ServerSentEventListener;
 import dev.langchain4j.http.client.sse.ServerSentEventParser;
-import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder;
+import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
-import org.springframework.boot.http.client.HttpComponentsClientHttpRequestFactoryBuilder;
+import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder;
 import org.springframework.boot.http.client.ClientHttpRequestFactorySettings;
+import org.springframework.boot.http.client.HttpComponentsClientHttpRequestFactoryBuilder;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,8 @@ import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 
 import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.net.SocketTimeoutException;
 import java.util.Map;
 
@@ -47,7 +50,10 @@ public class SpringRestClient implements HttpClient {
         }
         ClientHttpRequestFactoryBuilder<?> requestFactoryBuilder = ClientHttpRequestFactoryBuilder.detect();
         if (requestFactoryBuilder instanceof HttpComponentsClientHttpRequestFactoryBuilder httpComponentsBuilder) {
-            requestFactoryBuilder = httpComponentsBuilder.withHttpClientCustomizer(HttpClientBuilder::disableAutomaticRetries);
+            requestFactoryBuilder = httpComponentsBuilder.withHttpClientCustomizer(httpClientBuilder -> {
+                httpClientBuilder.disableAutomaticRetries();
+                applyProxy(httpClientBuilder, builder.proxy());
+            });
         }
         ClientHttpRequestFactory clientHttpRequestFactory = requestFactoryBuilder.build(settings);
 
@@ -73,6 +79,22 @@ public class SpringRestClient implements HttpClient {
 
     public static SpringRestClientBuilder builder() {
         return new SpringRestClientBuilder();
+    }
+
+    private static void applyProxy(HttpClientBuilder httpClientBuilder, Proxy proxy) {
+        if (proxy == null || proxy.type() == Proxy.Type.DIRECT) {
+            return;
+        }
+
+        if (proxy.type() != Proxy.Type.HTTP) {
+            throw new IllegalArgumentException("Only HTTP proxies are supported");
+        }
+
+        if (!(proxy.address() instanceof InetSocketAddress proxyAddress)) {
+            throw new IllegalArgumentException("Proxy address must be an InetSocketAddress");
+        }
+
+        httpClientBuilder.setProxy(new HttpHost(proxyAddress.getHostString(), proxyAddress.getPort()));
     }
 
     @Override

--- a/langchain4j-http-client-spring-restclient/src/main/java/dev/langchain4j/http/client/spring/restclient/SpringRestClientBuilder.java
+++ b/langchain4j-http-client-spring-restclient/src/main/java/dev/langchain4j/http/client/spring/restclient/SpringRestClientBuilder.java
@@ -4,6 +4,7 @@ import dev.langchain4j.http.client.HttpClientBuilder;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.web.client.RestClient;
 
+import java.net.Proxy;
 import java.time.Duration;
 
 public class SpringRestClientBuilder implements HttpClientBuilder {
@@ -13,6 +14,7 @@ public class SpringRestClientBuilder implements HttpClientBuilder {
     private Boolean createDefaultStreamingRequestExecutor = true;
     private Duration connectTimeout;
     private Duration readTimeout;
+    private Proxy proxy;
 
     public RestClient.Builder restClientBuilder() {
         return restClientBuilder;
@@ -60,6 +62,15 @@ public class SpringRestClientBuilder implements HttpClientBuilder {
     @Override
     public SpringRestClientBuilder readTimeout(Duration readTimeout) {
         this.readTimeout = readTimeout;
+        return this;
+    }
+
+    public Proxy proxy() {
+        return proxy;
+    }
+
+    public SpringRestClientBuilder proxy(Proxy proxy) {
+        this.proxy = proxy;
         return this;
     }
 

--- a/langchain4j-http-client-spring-restclient/src/test/java/dev/langchain4j/http/client/spring/restclient/SpringRestClientProxyIT.java
+++ b/langchain4j-http-client-spring-restclient/src/test/java/dev/langchain4j/http/client/spring/restclient/SpringRestClientProxyIT.java
@@ -1,0 +1,66 @@
+package dev.langchain4j.http.client.spring.restclient;
+
+import com.sun.net.httpserver.HttpServer;
+import dev.langchain4j.http.client.HttpMethod;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SpringRestClientProxyIT {
+
+    @Test
+    void should_route_requests_through_configured_http_proxy() throws IOException {
+        AtomicReference<String> requestedUri = new AtomicReference<>();
+
+        HttpServer proxyServer = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        proxyServer.createContext("/", exchange -> {
+            requestedUri.set(exchange.getRequestURI().toString());
+
+            byte[] body = "proxied".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream responseBody = exchange.getResponseBody()) {
+                responseBody.write(body);
+            }
+        });
+        proxyServer.start();
+
+        try {
+            int proxyPort = proxyServer.getAddress().getPort();
+            SpringRestClient client = SpringRestClient.builder()
+                    .proxy(new Proxy(Proxy.Type.HTTP, new InetSocketAddress("localhost", proxyPort)))
+                    .createDefaultStreamingRequestExecutor(false)
+                    .build();
+            HttpRequest request = HttpRequest.builder()
+                    .method(HttpMethod.GET)
+                    .url("http://example.com/proxy-test")
+                    .build();
+
+            SuccessfulHttpResponse response = client.execute(request);
+
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.body()).isEqualTo("proxied");
+            assertThat(requestedUri.get()).contains("proxy-test");
+        } finally {
+            proxyServer.stop(0);
+        }
+    }
+
+    @Test
+    void should_reject_non_http_proxy() {
+        assertThatThrownBy(() -> SpringRestClient.builder()
+                .proxy(new Proxy(Proxy.Type.SOCKS, new InetSocketAddress("localhost", 1080)))
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Only HTTP proxies are supported");
+    }
+}

--- a/langchain4j-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/openai/spring/AutoConfig.java
+++ b/langchain4j-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/openai/spring/AutoConfig.java
@@ -94,9 +94,13 @@ public class AutoConfig {
     @Bean(CHAT_MODEL_HTTP_CLIENT_BUILDER)
     @ConditionalOnProperty(PREFIX + ".chat-model.api-key")
     @ConditionalOnMissingBean(name = CHAT_MODEL_HTTP_CLIENT_BUILDER)
-    HttpClientBuilder openAiChatModelHttpClientBuilder(ObjectProvider<RestClient.Builder> restClientBuilder) {
+    HttpClientBuilder openAiChatModelHttpClientBuilder(
+            ObjectProvider<RestClient.Builder> restClientBuilder,
+            Properties properties
+    ) {
         return SpringRestClient.builder()
                 .restClientBuilder(restClientBuilder.getIfAvailable(RestClient::builder))
+                .proxy(ProxyProperties.toProxy(properties.chatModel().proxy()))
                 // executor is not needed for no-streaming OpenAiChatModel
                 .createDefaultStreamingRequestExecutor(false);
     }
@@ -151,9 +155,11 @@ public class AutoConfig {
     @ConditionalOnMissingBean(name = STREAMING_CHAT_MODEL_HTTP_CLIENT_BUILDER)
     HttpClientBuilder openAiStreamingChatModelHttpClientBuilder(
             ObjectProvider<RestClient.Builder> restClientBuilder,
+            Properties properties,
             @Qualifier(STREAMING_CHAT_MODEL_TASK_EXECUTOR) AsyncTaskExecutor executor) {
         return SpringRestClient.builder()
                 .restClientBuilder(restClientBuilder.getIfAvailable(RestClient::builder))
+                .proxy(ProxyProperties.toProxy(properties.streamingChatModel().proxy()))
                 .streamingRequestExecutor(executor);
     }
 
@@ -207,9 +213,13 @@ public class AutoConfig {
     @Bean(LANGUAGE_MODEL_HTTP_CLIENT_BUILDER)
     @ConditionalOnProperty(PREFIX + ".language-model.api-key")
     @ConditionalOnMissingBean(name = LANGUAGE_MODEL_HTTP_CLIENT_BUILDER)
-    HttpClientBuilder openAiLanguageModelHttpClientBuilder(ObjectProvider<RestClient.Builder> restClientBuilder) {
+    HttpClientBuilder openAiLanguageModelHttpClientBuilder(
+            ObjectProvider<RestClient.Builder> restClientBuilder,
+            Properties properties
+    ) {
         return SpringRestClient.builder()
                 .restClientBuilder(restClientBuilder.getIfAvailable(RestClient::builder))
+                .proxy(ProxyProperties.toProxy(properties.languageModel().proxy()))
                 // executor is not needed for no-streaming OpenAiLanguageModel
                 .createDefaultStreamingRequestExecutor(false);
     }
@@ -242,10 +252,12 @@ public class AutoConfig {
     @ConditionalOnMissingBean(name = STREAMING_LANGUAGE_MODEL_HTTP_CLIENT_BUILDER)
     HttpClientBuilder openAiStreamingLanguageModelHttpClientBuilder(
             @Qualifier(STREAMING_LANGUAGE_MODEL_TASK_EXECUTOR) AsyncTaskExecutor executor,
-            ObjectProvider<RestClient.Builder> restClientBuilder
+            ObjectProvider<RestClient.Builder> restClientBuilder,
+            Properties properties
     ) {
         return SpringRestClient.builder()
                 .restClientBuilder(restClientBuilder.getIfAvailable(RestClient::builder))
+                .proxy(ProxyProperties.toProxy(properties.streamingLanguageModel().proxy()))
                 .streamingRequestExecutor(executor);
     }
 
@@ -301,9 +313,13 @@ public class AutoConfig {
     @Bean(EMBEDDING_MODEL_HTTP_CLIENT_BUILDER)
     @ConditionalOnProperty(PREFIX + ".embedding-model.api-key")
     @ConditionalOnMissingBean(name = EMBEDDING_MODEL_HTTP_CLIENT_BUILDER)
-    HttpClientBuilder openAiEmbeddingModelHttpClientBuilder(ObjectProvider<RestClient.Builder> restClientBuilder) {
+    HttpClientBuilder openAiEmbeddingModelHttpClientBuilder(
+            ObjectProvider<RestClient.Builder> restClientBuilder,
+            Properties properties
+    ) {
         return SpringRestClient.builder()
                 .restClientBuilder(restClientBuilder.getIfAvailable(RestClient::builder))
+                .proxy(ProxyProperties.toProxy(properties.embeddingModel().proxy()))
                 // executor is not needed for no-streaming OpenAiEmbeddingModel
                 .createDefaultStreamingRequestExecutor(false);
     }
@@ -334,9 +350,13 @@ public class AutoConfig {
     @Bean(MODERATION_MODEL_HTTP_CLIENT_BUILDER)
     @ConditionalOnProperty(PREFIX + ".moderation-model.api-key")
     @ConditionalOnMissingBean(name = MODERATION_MODEL_HTTP_CLIENT_BUILDER)
-    HttpClientBuilder openAiModerationModelHttpClientBuilder(ObjectProvider<RestClient.Builder> restClientBuilder) {
+    HttpClientBuilder openAiModerationModelHttpClientBuilder(
+            ObjectProvider<RestClient.Builder> restClientBuilder,
+            Properties properties
+    ) {
         return SpringRestClient.builder()
                 .restClientBuilder(restClientBuilder.getIfAvailable(RestClient::builder))
+                .proxy(ProxyProperties.toProxy(properties.moderationModel().proxy()))
                 // executor is not needed for no-streaming OpenAiModerationModel
                 .createDefaultStreamingRequestExecutor(false);
     }
@@ -374,9 +394,13 @@ public class AutoConfig {
     @Bean(IMAGE_MODEL_HTTP_CLIENT_BUILDER)
     @ConditionalOnProperty(PREFIX + ".image-model.api-key")
     @ConditionalOnMissingBean(name = IMAGE_MODEL_HTTP_CLIENT_BUILDER)
-    HttpClientBuilder openAiImageModelHttpClientBuilder(ObjectProvider<RestClient.Builder> restClientBuilder) {
+    HttpClientBuilder openAiImageModelHttpClientBuilder(
+            ObjectProvider<RestClient.Builder> restClientBuilder,
+            Properties properties
+    ) {
         return SpringRestClient.builder()
                 .restClientBuilder(restClientBuilder.getIfAvailable(RestClient::builder))
+                .proxy(ProxyProperties.toProxy(properties.imageModel().proxy()))
                 // executor is not needed for no-streaming OpenAiImageModel
                 .createDefaultStreamingRequestExecutor(false);
     }

--- a/langchain4j-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/openai/spring/ChatModelProperties.java
+++ b/langchain4j-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/openai/spring/ChatModelProperties.java
@@ -35,6 +35,7 @@ record ChatModelProperties(
         Boolean returnThinking,
         Duration timeout,
         Integer maxRetries,
+        ProxyProperties proxy,
         Boolean logRequests,
         Boolean logResponses,
         Map<String, String> customHeaders,

--- a/langchain4j-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/openai/spring/EmbeddingModelProperties.java
+++ b/langchain4j-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/openai/spring/EmbeddingModelProperties.java
@@ -14,6 +14,7 @@ record EmbeddingModelProperties(
         String user,
         Duration timeout,
         Integer maxRetries,
+        ProxyProperties proxy,
         Boolean logRequests,
         Boolean logResponses,
         Map<String, String> customHeaders,

--- a/langchain4j-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/openai/spring/ImageModelProperties.java
+++ b/langchain4j-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/openai/spring/ImageModelProperties.java
@@ -18,6 +18,7 @@ record ImageModelProperties(
         String moderation,
         Duration timeout,
         Integer maxRetries,
+        ProxyProperties proxy,
         Boolean logRequests,
         Boolean logResponses,
         Map<String, String> customHeaders,

--- a/langchain4j-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/openai/spring/LanguageModelProperties.java
+++ b/langchain4j-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/openai/spring/LanguageModelProperties.java
@@ -12,6 +12,7 @@ record LanguageModelProperties(
         Double temperature,
         Duration timeout,
         Integer maxRetries,
+        ProxyProperties proxy,
         Boolean logRequests,
         Boolean logResponses,
         Map<String, String> customHeaders,

--- a/langchain4j-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/openai/spring/ModerationModelProperties.java
+++ b/langchain4j-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/openai/spring/ModerationModelProperties.java
@@ -11,6 +11,7 @@ record ModerationModelProperties(
         String modelName,
         Duration timeout,
         Integer maxRetries,
+        ProxyProperties proxy,
         Boolean logRequests,
         Boolean logResponses,
         Map<String, String> customHeaders,

--- a/langchain4j-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/openai/spring/ProxyProperties.java
+++ b/langchain4j-open-ai-spring-boot-starter/src/main/java/dev/langchain4j/openai/spring/ProxyProperties.java
@@ -1,0 +1,23 @@
+package dev.langchain4j.openai.spring;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+
+record ProxyProperties(
+        Proxy.Type type,
+        String host,
+        Integer port
+) {
+
+    static Proxy toProxy(ProxyProperties properties) {
+        if (properties == null || properties.type() == null || properties.type() == Proxy.Type.DIRECT) {
+            return null;
+        }
+
+        if (properties.host() == null || properties.port() == null) {
+            throw new IllegalArgumentException("Proxy host and port must be configured");
+        }
+
+        return new Proxy(properties.type(), new InetSocketAddress(properties.host(), properties.port()));
+    }
+}

--- a/langchain4j-open-ai-spring-boot-starter/src/test/java/dev/langchain4j/openai/spring/AutoConfigTest.java
+++ b/langchain4j-open-ai-spring-boot-starter/src/test/java/dev/langchain4j/openai/spring/AutoConfigTest.java
@@ -1,0 +1,52 @@
+package dev.langchain4j.openai.spring;
+
+import dev.langchain4j.http.client.spring.restclient.SpringRestClientBuilder;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AutoConfigTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(AutoConfig.class));
+
+    @Test
+    void shouldConfigureProxyForChatModelHttpClientBuilder() {
+        contextRunner
+                .withPropertyValues(
+                        "langchain4j.open-ai.chat-model.api-key=test-api-key",
+                        "langchain4j.open-ai.chat-model.proxy.type=HTTP",
+                        "langchain4j.open-ai.chat-model.proxy.host=proxy.example.com",
+                        "langchain4j.open-ai.chat-model.proxy.port=8080")
+                .run(context -> assertProxy(context.getBean(
+                        "openAiChatModelHttpClientBuilder",
+                        SpringRestClientBuilder.class)));
+    }
+
+    @Test
+    void shouldConfigureProxyForImageModelHttpClientBuilder() {
+        contextRunner
+                .withPropertyValues(
+                        "langchain4j.open-ai.image-model.api-key=test-api-key",
+                        "langchain4j.open-ai.image-model.proxy.type=HTTP",
+                        "langchain4j.open-ai.image-model.proxy.host=proxy.example.com",
+                        "langchain4j.open-ai.image-model.proxy.port=8080")
+                .run(context -> assertProxy(context.getBean(
+                        "openAiImageModelHttpClientBuilder",
+                        SpringRestClientBuilder.class)));
+    }
+
+    private static void assertProxy(SpringRestClientBuilder httpClientBuilder) {
+        Proxy proxy = httpClientBuilder.proxy();
+        assertThat(proxy.type()).isEqualTo(Proxy.Type.HTTP);
+
+        InetSocketAddress address = (InetSocketAddress) proxy.address();
+        assertThat(address.getHostString()).isEqualTo("proxy.example.com");
+        assertThat(address.getPort()).isEqualTo(8080);
+    }
+}

--- a/langchain4j-open-ai-spring-boot4-starter/src/main/java/dev/langchain4j/openai/spring/OpenAiAutoConfiguration.java
+++ b/langchain4j-open-ai-spring-boot4-starter/src/main/java/dev/langchain4j/openai/spring/OpenAiAutoConfiguration.java
@@ -94,9 +94,13 @@ public class OpenAiAutoConfiguration {
     @Bean(CHAT_MODEL_HTTP_CLIENT_BUILDER)
     @ConditionalOnProperty(PREFIX + ".chat-model.api-key")
     @ConditionalOnMissingBean(name = CHAT_MODEL_HTTP_CLIENT_BUILDER)
-    HttpClientBuilder openAiChatModelHttpClientBuilder(ObjectProvider<RestClient.Builder> restClientBuilder) {
+    HttpClientBuilder openAiChatModelHttpClientBuilder(
+            ObjectProvider<RestClient.Builder> restClientBuilder,
+            OpenAiProperties properties
+    ) {
         return SpringRestClient.builder()
                 .restClientBuilder(restClientBuilder.getIfAvailable(RestClient::builder))
+                .proxy(ProxyProperties.toProxy(properties.chatModel().proxy()))
                 // executor is not needed for no-streaming OpenAiChatModel
                 .createDefaultStreamingRequestExecutor(false);
     }
@@ -151,9 +155,11 @@ public class OpenAiAutoConfiguration {
     @ConditionalOnMissingBean(name = STREAMING_CHAT_MODEL_HTTP_CLIENT_BUILDER)
     HttpClientBuilder openAiStreamingChatModelHttpClientBuilder(
             ObjectProvider<RestClient.Builder> restClientBuilder,
+            OpenAiProperties properties,
             @Qualifier(STREAMING_CHAT_MODEL_TASK_EXECUTOR) AsyncTaskExecutor executor) {
         return SpringRestClient.builder()
                 .restClientBuilder(restClientBuilder.getIfAvailable(RestClient::builder))
+                .proxy(ProxyProperties.toProxy(properties.streamingChatModel().proxy()))
                 .streamingRequestExecutor(executor);
     }
 
@@ -207,9 +213,13 @@ public class OpenAiAutoConfiguration {
     @Bean(LANGUAGE_MODEL_HTTP_CLIENT_BUILDER)
     @ConditionalOnProperty(PREFIX + ".language-model.api-key")
     @ConditionalOnMissingBean(name = LANGUAGE_MODEL_HTTP_CLIENT_BUILDER)
-    HttpClientBuilder openAiLanguageModelHttpClientBuilder(ObjectProvider<RestClient.Builder> restClientBuilder) {
+    HttpClientBuilder openAiLanguageModelHttpClientBuilder(
+            ObjectProvider<RestClient.Builder> restClientBuilder,
+            OpenAiProperties properties
+    ) {
         return SpringRestClient.builder()
                 .restClientBuilder(restClientBuilder.getIfAvailable(RestClient::builder))
+                .proxy(ProxyProperties.toProxy(properties.languageModel().proxy()))
                 // executor is not needed for no-streaming OpenAiLanguageModel
                 .createDefaultStreamingRequestExecutor(false);
     }
@@ -242,10 +252,12 @@ public class OpenAiAutoConfiguration {
     @ConditionalOnMissingBean(name = STREAMING_LANGUAGE_MODEL_HTTP_CLIENT_BUILDER)
     HttpClientBuilder openAiStreamingLanguageModelHttpClientBuilder(
             @Qualifier(STREAMING_LANGUAGE_MODEL_TASK_EXECUTOR) AsyncTaskExecutor executor,
-            ObjectProvider<RestClient.Builder> restClientBuilder
+            ObjectProvider<RestClient.Builder> restClientBuilder,
+            OpenAiProperties properties
     ) {
         return SpringRestClient.builder()
                 .restClientBuilder(restClientBuilder.getIfAvailable(RestClient::builder))
+                .proxy(ProxyProperties.toProxy(properties.streamingLanguageModel().proxy()))
                 .streamingRequestExecutor(executor);
     }
 
@@ -301,9 +313,13 @@ public class OpenAiAutoConfiguration {
     @Bean(EMBEDDING_MODEL_HTTP_CLIENT_BUILDER)
     @ConditionalOnProperty(PREFIX + ".embedding-model.api-key")
     @ConditionalOnMissingBean(name = EMBEDDING_MODEL_HTTP_CLIENT_BUILDER)
-    HttpClientBuilder openAiEmbeddingModelHttpClientBuilder(ObjectProvider<RestClient.Builder> restClientBuilder) {
+    HttpClientBuilder openAiEmbeddingModelHttpClientBuilder(
+            ObjectProvider<RestClient.Builder> restClientBuilder,
+            OpenAiProperties properties
+    ) {
         return SpringRestClient.builder()
                 .restClientBuilder(restClientBuilder.getIfAvailable(RestClient::builder))
+                .proxy(ProxyProperties.toProxy(properties.embeddingModel().proxy()))
                 // executor is not needed for no-streaming OpenAiEmbeddingModel
                 .createDefaultStreamingRequestExecutor(false);
     }
@@ -334,9 +350,13 @@ public class OpenAiAutoConfiguration {
     @Bean(MODERATION_MODEL_HTTP_CLIENT_BUILDER)
     @ConditionalOnProperty(PREFIX + ".moderation-model.api-key")
     @ConditionalOnMissingBean(name = MODERATION_MODEL_HTTP_CLIENT_BUILDER)
-    HttpClientBuilder openAiModerationModelHttpClientBuilder(ObjectProvider<RestClient.Builder> restClientBuilder) {
+    HttpClientBuilder openAiModerationModelHttpClientBuilder(
+            ObjectProvider<RestClient.Builder> restClientBuilder,
+            OpenAiProperties properties
+    ) {
         return SpringRestClient.builder()
                 .restClientBuilder(restClientBuilder.getIfAvailable(RestClient::builder))
+                .proxy(ProxyProperties.toProxy(properties.moderationModel().proxy()))
                 // executor is not needed for no-streaming OpenAiModerationModel
                 .createDefaultStreamingRequestExecutor(false);
     }
@@ -374,9 +394,13 @@ public class OpenAiAutoConfiguration {
     @Bean(IMAGE_MODEL_HTTP_CLIENT_BUILDER)
     @ConditionalOnProperty(PREFIX + ".image-model.api-key")
     @ConditionalOnMissingBean(name = IMAGE_MODEL_HTTP_CLIENT_BUILDER)
-    HttpClientBuilder openAiImageModelHttpClientBuilder(ObjectProvider<RestClient.Builder> restClientBuilder) {
+    HttpClientBuilder openAiImageModelHttpClientBuilder(
+            ObjectProvider<RestClient.Builder> restClientBuilder,
+            OpenAiProperties properties
+    ) {
         return SpringRestClient.builder()
                 .restClientBuilder(restClientBuilder.getIfAvailable(RestClient::builder))
+                .proxy(ProxyProperties.toProxy(properties.imageModel().proxy()))
                 // executor is not needed for no-streaming OpenAiImageModel
                 .createDefaultStreamingRequestExecutor(false);
     }

--- a/langchain4j-open-ai-spring-boot4-starter/src/main/java/dev/langchain4j/openai/spring/OpenAiChatModelProperties.java
+++ b/langchain4j-open-ai-spring-boot4-starter/src/main/java/dev/langchain4j/openai/spring/OpenAiChatModelProperties.java
@@ -35,6 +35,7 @@ record OpenAiChatModelProperties(
         Boolean returnThinking,
         Duration timeout,
         Integer maxRetries,
+        ProxyProperties proxy,
         Boolean logRequests,
         Boolean logResponses,
         Map<String, String> customHeaders,

--- a/langchain4j-open-ai-spring-boot4-starter/src/main/java/dev/langchain4j/openai/spring/OpenAiEmbeddingModelProperties.java
+++ b/langchain4j-open-ai-spring-boot4-starter/src/main/java/dev/langchain4j/openai/spring/OpenAiEmbeddingModelProperties.java
@@ -14,6 +14,7 @@ record OpenAiEmbeddingModelProperties(
         String user,
         Duration timeout,
         Integer maxRetries,
+        ProxyProperties proxy,
         Boolean logRequests,
         Boolean logResponses,
         Map<String, String> customHeaders,

--- a/langchain4j-open-ai-spring-boot4-starter/src/main/java/dev/langchain4j/openai/spring/OpenAiImageModelProperties.java
+++ b/langchain4j-open-ai-spring-boot4-starter/src/main/java/dev/langchain4j/openai/spring/OpenAiImageModelProperties.java
@@ -18,6 +18,7 @@ record OpenAiImageModelProperties(
         String moderation,
         Duration timeout,
         Integer maxRetries,
+        ProxyProperties proxy,
         Boolean logRequests,
         Boolean logResponses,
         Map<String, String> customHeaders,

--- a/langchain4j-open-ai-spring-boot4-starter/src/main/java/dev/langchain4j/openai/spring/OpenAiLanguageModelProperties.java
+++ b/langchain4j-open-ai-spring-boot4-starter/src/main/java/dev/langchain4j/openai/spring/OpenAiLanguageModelProperties.java
@@ -12,6 +12,7 @@ record OpenAiLanguageModelProperties(
         Double temperature,
         Duration timeout,
         Integer maxRetries,
+        ProxyProperties proxy,
         Boolean logRequests,
         Boolean logResponses,
         Map<String, String> customHeaders,

--- a/langchain4j-open-ai-spring-boot4-starter/src/main/java/dev/langchain4j/openai/spring/OpenAiModerationModelProperties.java
+++ b/langchain4j-open-ai-spring-boot4-starter/src/main/java/dev/langchain4j/openai/spring/OpenAiModerationModelProperties.java
@@ -11,6 +11,7 @@ record OpenAiModerationModelProperties(
         String modelName,
         Duration timeout,
         Integer maxRetries,
+        ProxyProperties proxy,
         Boolean logRequests,
         Boolean logResponses,
         Map<String, String> customHeaders,

--- a/langchain4j-open-ai-spring-boot4-starter/src/main/java/dev/langchain4j/openai/spring/ProxyProperties.java
+++ b/langchain4j-open-ai-spring-boot4-starter/src/main/java/dev/langchain4j/openai/spring/ProxyProperties.java
@@ -1,0 +1,23 @@
+package dev.langchain4j.openai.spring;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+
+record ProxyProperties(
+        Proxy.Type type,
+        String host,
+        Integer port
+) {
+
+    static Proxy toProxy(ProxyProperties properties) {
+        if (properties == null || properties.type() == null || properties.type() == Proxy.Type.DIRECT) {
+            return null;
+        }
+
+        if (properties.host() == null || properties.port() == null) {
+            throw new IllegalArgumentException("Proxy host and port must be configured");
+        }
+
+        return new Proxy(properties.type(), new InetSocketAddress(properties.host(), properties.port()));
+    }
+}

--- a/langchain4j-open-ai-spring-boot4-starter/src/test/java/dev/langchain4j/openai/spring/OpenAiAutoConfigurationTest.java
+++ b/langchain4j-open-ai-spring-boot4-starter/src/test/java/dev/langchain4j/openai/spring/OpenAiAutoConfigurationTest.java
@@ -1,0 +1,52 @@
+package dev.langchain4j.openai.spring;
+
+import dev.langchain4j.http.client.spring.restclient.SpringRestClientBuilder;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpenAiAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(OpenAiAutoConfiguration.class));
+
+    @Test
+    void shouldConfigureProxyForChatModelHttpClientBuilder() {
+        contextRunner
+                .withPropertyValues(
+                        "langchain4j.open-ai.chat-model.api-key=test-api-key",
+                        "langchain4j.open-ai.chat-model.proxy.type=HTTP",
+                        "langchain4j.open-ai.chat-model.proxy.host=proxy.example.com",
+                        "langchain4j.open-ai.chat-model.proxy.port=8080")
+                .run(context -> assertProxy(context.getBean(
+                        "openAiChatModelHttpClientBuilder",
+                        SpringRestClientBuilder.class)));
+    }
+
+    @Test
+    void shouldConfigureProxyForImageModelHttpClientBuilder() {
+        contextRunner
+                .withPropertyValues(
+                        "langchain4j.open-ai.image-model.api-key=test-api-key",
+                        "langchain4j.open-ai.image-model.proxy.type=HTTP",
+                        "langchain4j.open-ai.image-model.proxy.host=proxy.example.com",
+                        "langchain4j.open-ai.image-model.proxy.port=8080")
+                .run(context -> assertProxy(context.getBean(
+                        "openAiImageModelHttpClientBuilder",
+                        SpringRestClientBuilder.class)));
+    }
+
+    private static void assertProxy(SpringRestClientBuilder httpClientBuilder) {
+        Proxy proxy = httpClientBuilder.proxy();
+        assertThat(proxy.type()).isEqualTo(Proxy.Type.HTTP);
+
+        InetSocketAddress address = (InetSocketAddress) proxy.address();
+        assertThat(address.getHostString()).isEqualTo("proxy.example.com");
+        assertThat(address.getPort()).isEqualTo(8080);
+    }
+}


### PR DESCRIPTION
## Issue
Fixes langchain4j/langchain4j#3540

## Change
The OpenAI migration in langchain4j/langchain4j#2529 intentionally moved proxy configuration from `OpenAi*Model` builders to the HTTP client layer and noted that the old Spring Boot proxy properties would stop working. This PR keeps that new architecture and maps the existing Spring Boot properties onto the default Spring `RestClient` HTTP client builder instead of reintroducing model-level proxy configuration.

Changes:
- Restore OpenAI proxy property binding for Boot 3 and Boot 4 starters.
- Wire model-specific proxy settings into the default `SpringRestClientBuilder` beans.
- Add HTTP proxy support to both Spring RestClient HTTP client modules via the Apache HttpClient5 customizer.
- Add regression tests for chat/image proxy binding and positive/negative HTTP proxy routing.

## General checklist
- [X] There are no breaking changes
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)

## Tests
- `./mvnw -pl langchain4j-http-client-spring-restclient,langchain4j-http-client-spring-boot4-restclient -Dtest=SpringRestClientProxyIT test`
- `./mvnw -pl langchain4j-open-ai-spring-boot-starter,langchain4j-open-ai-spring-boot4-starter -am -Dtest=AutoConfigTest,OpenAiAutoConfigurationTest -Dsurefire.failIfNoSpecifiedTests=false test`