### PR TITLE
Test every property of the Anthropic starters, and fix what that uncovered

### DIFF
--- a/langchain4j-anthropic-spring-boot-starter/src/main/java/dev/langchain4j/anthropic/spring/AutoConfig.java
+++ b/langchain4j-anthropic-spring-boot-starter/src/main/java/dev/langchain4j/anthropic/spring/AutoConfig.java
@@ -1,5 +1,8 @@
 package dev.langchain4j.anthropic.spring;
 
+import java.util.Collection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
 import dev.langchain4j.model.anthropic.AnthropicStreamingChatModel;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
@@ -14,6 +17,8 @@ import static dev.langchain4j.anthropic.spring.Properties.PREFIX;
 @AutoConfiguration
 @EnableConfigurationProperties(Properties.class)
 public class AutoConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(AutoConfig.class);
 
     @Bean
     @ConditionalOnProperty(PREFIX + ".chat-model.api-key")
@@ -51,6 +56,9 @@ public class AutoConfig {
     AnthropicStreamingChatModel anthropicStreamingChatModel(Properties properties,
                                                             ObjectProvider<ChatModelListener> listeners) {
         ChatModelProperties chatModelProperties = properties.getStreamingChatModel();
+        warnIfSet(chatModelProperties.getMaxRetries(), "streaming-chat-model", "max-retries",
+                "a response that has already started streaming cannot be retried");
+
         return AnthropicStreamingChatModel.builder()
                 .baseUrl(chatModelProperties.getBaseUrl())
                 .apiKey(chatModelProperties.getApiKey())
@@ -62,6 +70,7 @@ public class AutoConfig {
                 .topK(chatModelProperties.getTopK())
                 .maxTokens(chatModelProperties.getMaxTokens())
                 .stopSequences(chatModelProperties.getStopSequences())
+                .toolChoice(chatModelProperties.getToolChoice())
                 .cacheSystemMessages(chatModelProperties.getCacheSystemMessages())
                 .cacheTools(chatModelProperties.getCacheTools())
                 .thinkingType(chatModelProperties.getThinkingType())
@@ -75,4 +84,16 @@ public class AutoConfig {
                 .listeners(listeners.orderedStream().toList())
                 .build();
     }
+
+    /**
+     * Some properties are shared between the sync and the streaming variants of a model, but the streaming model
+     * cannot honour all of them. Rather than silently ignoring such a property, say so once at startup.
+     */
+    private static void warnIfSet(Object value, String model, String property, String reason) {
+        boolean set = value instanceof Collection<?> collection ? !collection.isEmpty() : value != null;
+        if (set) {
+            log.warn("{}.{}.{} is set, but it is ignored: {}", PREFIX, model, property, reason);
+        }
+    }
+
 }

--- a/langchain4j-anthropic-spring-boot-starter/src/test/java/dev/langchain4j/anthropic/spring/IgnoredPropertyWarningTest.java
+++ b/langchain4j-anthropic-spring-boot-starter/src/test/java/dev/langchain4j/anthropic/spring/IgnoredPropertyWarningTest.java
@@ -1,0 +1,92 @@
+package dev.langchain4j.anthropic.spring;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The streaming chat model reuses the properties of its sync counterpart, but cannot honour all of them. Setting
+ * such a property has to be reported, otherwise it looks like it took effect.
+ */
+class IgnoredPropertyWarningTest {
+
+    private ListAppender<ILoggingEvent> appender;
+    private ch.qos.logback.classic.Logger logger;
+
+    ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(AutoConfig.class));
+
+    @BeforeEach
+    void setUp() {
+        logger = ((LoggerContext) LoggerFactory.getILoggerFactory()).getLogger(AutoConfig.class);
+        appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(appender);
+    }
+
+    private List<String> warnings() {
+        return appender.list.stream()
+                .filter(event -> event.getLevel() == Level.WARN)
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+    }
+
+    @Test
+    void should_warn_when_streaming_chat_model_is_given_a_property_it_ignores() {
+        contextRunner
+                .withPropertyValues(
+                        "langchain4j.anthropic.streaming-chat-model.api-key=test-api-key",
+                        "langchain4j.anthropic.streaming-chat-model.model-name=claude-haiku-4-5-20251001",
+                        "langchain4j.anthropic.streaming-chat-model.max-retries=3"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(StreamingChatModel.class);
+
+                    assertThat(warnings()).anySatisfy(warning -> assertThat(warning)
+                            .contains("langchain4j.anthropic.streaming-chat-model.max-retries")
+                            .contains("ignored"));
+                });
+    }
+
+    @Test
+    void should_not_warn_when_the_ignored_property_is_not_set() {
+        contextRunner
+                .withPropertyValues(
+                        "langchain4j.anthropic.streaming-chat-model.api-key=test-api-key",
+                        "langchain4j.anthropic.streaming-chat-model.model-name=claude-haiku-4-5-20251001",
+                        "langchain4j.anthropic.streaming-chat-model.temperature=0.0"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(StreamingChatModel.class);
+                    assertThat(warnings()).isEmpty();
+                });
+    }
+
+    @Test
+    void should_not_warn_when_the_same_property_is_set_on_the_sync_model() {
+        contextRunner
+                .withPropertyValues(
+                        "langchain4j.anthropic.chat-model.api-key=test-api-key",
+                        "langchain4j.anthropic.chat-model.model-name=claude-haiku-4-5-20251001",
+                        "langchain4j.anthropic.chat-model.max-retries=3"
+                )
+                .run(context -> assertThat(warnings()).isEmpty());
+    }
+}

--- a/langchain4j-anthropic-spring-boot-starter/src/test/java/dev/langchain4j/anthropic/spring/PropertyBindingTest.java
+++ b/langchain4j-anthropic-spring-boot-starter/src/test/java/dev/langchain4j/anthropic/spring/PropertyBindingTest.java
@@ -1,0 +1,402 @@
+package dev.langchain4j.anthropic.spring;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.TimeoutException;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Verifies that every property this starter exposes actually reaches the Anthropic API, so that a typo in the
+ * auto-configuration cannot go unnoticed. The API is stubbed, so no API key and no network access are required.
+ * <p>
+ * A few properties cannot be observed on the wire and are covered by their effect instead: {@code timeout} and
+ * {@code max-retries} by how the client behaves, and {@code return-thinking} by what the model reports.
+ * <p>
+ * Two properties are deliberately not asserted: {@code log-requests} and {@code log-responses} only change what is
+ * written to the log, so they are merely set here to make sure they bind. Note also that {@code max-retries} exists
+ * on the streaming chat model properties but is not supported by
+ * {@link dev.langchain4j.model.anthropic.AnthropicStreamingChatModel}, so it has no effect there.
+ * <p>
+ * {@code base-url} needs no assertion of its own: nothing below would reach the stub server without it.
+ */
+@WireMockTest
+class PropertyBindingTest {
+
+    private static final String API_KEY = "test-api-key";
+    private static final String MODEL_NAME = "claude-haiku-4-5-20251001";
+    private static final String MESSAGES_PATH = "/v1/messages";
+
+    private static final String MESSAGE_RESPONSE =
+            """
+            {
+              "id": "msg_1",
+              "type": "message",
+              "role": "assistant",
+              "model": "claude-haiku-4-5-20251001",
+              "content": [{"type": "text", "text": "ok"}],
+              "stop_reason": "end_turn",
+              "usage": {"input_tokens": 10, "output_tokens": 1}
+            }
+            """;
+
+    private static final String THINKING_RESPONSE =
+            """
+            {
+              "id": "msg_1",
+              "type": "message",
+              "role": "assistant",
+              "model": "claude-haiku-4-5-20251001",
+              "content": [
+                {"type": "thinking", "thinking": "let me think", "signature": "sig"},
+                {"type": "text", "text": "ok"}
+              ],
+              "stop_reason": "end_turn",
+              "usage": {"input_tokens": 10, "output_tokens": 1}
+            }
+            """;
+
+    private static final String MESSAGE_SSE =
+            """
+            event: message_start
+            data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant",\
+            "model":"claude-haiku-4-5-20251001","content":[],"usage":{"input_tokens":10,"output_tokens":0}}}
+
+            event: content_block_start
+            data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}
+
+            event: content_block_stop
+            data: {"type":"content_block_stop","index":0}
+
+            event: message_delta
+            data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}
+
+            event: message_stop
+            data: {"type":"message_stop"}
+
+            """;
+
+    private static final String THINKING_SSE =
+            """
+            event: message_start
+            data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant",\
+            "model":"claude-haiku-4-5-20251001","content":[],"usage":{"input_tokens":10,"output_tokens":0}}}
+
+            event: content_block_start
+            data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"let me think"}}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig"}}
+
+            event: content_block_stop
+            data: {"type":"content_block_stop","index":0}
+
+            event: content_block_start
+            data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"ok"}}
+
+            event: content_block_stop
+            data: {"type":"content_block_stop","index":1}
+
+            event: message_delta
+            data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}
+
+            event: message_stop
+            data: {"type":"message_stop"}
+
+            """;
+
+    private String baseUrl;
+
+    ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(AutoConfig.class));
+
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wireMock) {
+        baseUrl = wireMock.getHttpBaseUrl() + "/v1";
+    }
+
+    private String[] allChatModelProperties(String prefix) {
+        return new String[] {
+            prefix + ".base-url=" + baseUrl,
+            prefix + ".api-key=" + API_KEY,
+            prefix + ".version=2023-06-01",
+            prefix + ".beta=tools-2024-04-04",
+            prefix + ".model-name=" + MODEL_NAME,
+            prefix + ".temperature=0.3",
+            prefix + ".top-p=0.4",
+            prefix + ".top-k=5",
+            prefix + ".max-tokens=11",
+            prefix + ".stop-sequences=alpha,beta",
+            prefix + ".tool-choice=REQUIRED",
+            prefix + ".cache-system-messages=true",
+            prefix + ".cache-tools=true",
+            prefix + ".thinking-type=enabled",
+            prefix + ".thinking-budget-tokens=1024",
+            prefix + ".send-thinking=true",
+            prefix + ".custom-parameters.custom-key=custom-value",
+            prefix + ".timeout=PT30S",
+            prefix + ".log-requests=true",
+            prefix + ".log-responses=true"
+        };
+    }
+
+    private static void assertAllChatModelPropertiesOnTheWire() {
+        WireMock.verify(postRequestedFor(urlPathEqualTo(MESSAGES_PATH))
+                .withHeader("x-api-key", equalTo(API_KEY))
+                .withHeader("anthropic-version", equalTo("2023-06-01"))
+                .withHeader("anthropic-beta", equalTo("tools-2024-04-04"))
+                .withRequestBody(matchingJsonPath("$.model", equalTo(MODEL_NAME)))
+                .withRequestBody(matchingJsonPath("$.temperature", equalTo("0.3")))
+                .withRequestBody(matchingJsonPath("$.top_p", equalTo("0.4")))
+                .withRequestBody(matchingJsonPath("$.top_k", equalTo("5")))
+                .withRequestBody(matchingJsonPath("$.max_tokens", equalTo("11")))
+                .withRequestBody(matchingJsonPath("$.stop_sequences[0]", equalTo("alpha")))
+                .withRequestBody(matchingJsonPath("$.stop_sequences[1]", equalTo("beta")))
+                .withRequestBody(matchingJsonPath("$.tool_choice.type", equalTo("any")))
+                .withRequestBody(matchingJsonPath("$.system[0].cache_control.type", equalTo("ephemeral")))
+                .withRequestBody(matchingJsonPath("$.tools[0].cache_control.type", equalTo("ephemeral")))
+                .withRequestBody(matchingJsonPath("$.thinking.type", equalTo("enabled")))
+                .withRequestBody(matchingJsonPath("$.thinking.budget_tokens", equalTo("1024")))
+                .withRequestBody(matchingJsonPath("$.custom-key", equalTo("custom-value"))));
+    }
+
+    /**
+     * Carries everything the properties above need in order to show up: a system message for
+     * {@code cache-system-messages}, a tool for {@code cache-tools} and {@code tool-choice}, and an earlier reply
+     * with thinking for {@code send-thinking}.
+     */
+    private static ChatRequest requestExercisingEveryProperty() {
+        return ChatRequest.builder()
+                .messages(
+                        SystemMessage.from("be brief"),
+                        UserMessage.from("hi"),
+                        AiMessage.builder()
+                                .text("earlier answer")
+                                .thinking("earlier thinking")
+                                .attributes(Map.of("thinking_signature", "sig"))
+                                .build(),
+                        UserMessage.from("and now?"))
+                .toolSpecifications(ToolSpecification.builder()
+                        .name("getCurrentDate")
+                        .description("get the current date")
+                        .build())
+                .build();
+    }
+
+    @Test
+    void should_bind_all_chat_model_properties() {
+        stubMessage();
+
+        contextRunner
+                .withPropertyValues(allChatModelProperties("langchain4j.anthropic.chat-model"))
+                .run(context -> {
+                    context.getBean(ChatModel.class).chat(requestExercisingEveryProperty());
+
+                    assertAllChatModelPropertiesOnTheWire();
+
+                    // send-thinking: the thinking of the earlier reply is sent back
+                    assertThat(WireMock.findAll(postRequestedFor(urlPathEqualTo(MESSAGES_PATH)))
+                                    .get(0)
+                                    .getBodyAsString())
+                            .contains("earlier thinking");
+                });
+    }
+
+    @Test
+    void should_bind_all_streaming_chat_model_properties() {
+        stubStreamedMessage();
+
+        contextRunner
+                .withPropertyValues(allChatModelProperties("langchain4j.anthropic.streaming-chat-model"))
+                .run(context -> {
+                    chat(context.getBean(StreamingChatModel.class), requestExercisingEveryProperty());
+
+                    assertAllChatModelPropertiesOnTheWire();
+                });
+    }
+
+    @Test
+    void should_bind_chat_model_return_thinking() {
+        WireMock.stubFor(post(urlPathEqualTo(MESSAGES_PATH)).willReturn(okJson(THINKING_RESPONSE)));
+
+        for (boolean returnThinking : new boolean[] {true, false}) {
+            contextRunner
+                    .withPropertyValues(
+                            "langchain4j.anthropic.chat-model.base-url=" + baseUrl,
+                            "langchain4j.anthropic.chat-model.api-key=" + API_KEY,
+                            "langchain4j.anthropic.chat-model.model-name=" + MODEL_NAME,
+                            "langchain4j.anthropic.chat-model.max-tokens=20",
+                            "langchain4j.anthropic.chat-model.return-thinking=" + returnThinking
+                    )
+                    .run(context -> {
+                        ChatResponse response = context.getBean(ChatModel.class)
+                                .chat(ChatRequest.builder().messages(UserMessage.from("hi")).build());
+
+                        if (returnThinking) {
+                            assertThat(response.aiMessage().thinking()).isEqualTo("let me think");
+                        } else {
+                            assertThat(response.aiMessage().thinking()).isNull();
+                        }
+                    });
+        }
+    }
+
+    @Test
+    void should_bind_streaming_chat_model_return_thinking() throws Exception {
+        WireMock.stubFor(post(urlPathEqualTo(MESSAGES_PATH)).willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/event-stream")
+                .withBody(THINKING_SSE)));
+
+        for (boolean returnThinking : new boolean[] {true, false}) {
+            contextRunner
+                    .withPropertyValues(
+                            "langchain4j.anthropic.streaming-chat-model.base-url=" + baseUrl,
+                            "langchain4j.anthropic.streaming-chat-model.api-key=" + API_KEY,
+                            "langchain4j.anthropic.streaming-chat-model.model-name=" + MODEL_NAME,
+                            "langchain4j.anthropic.streaming-chat-model.max-tokens=20",
+                            "langchain4j.anthropic.streaming-chat-model.return-thinking=" + returnThinking
+                    )
+                    .run(context -> {
+                        ChatResponse response = chat(context.getBean(StreamingChatModel.class),
+                                ChatRequest.builder().messages(UserMessage.from("hi")).build());
+
+                        if (returnThinking) {
+                            assertThat(response.aiMessage().thinking()).isEqualTo("let me think");
+                        } else {
+                            assertThat(response.aiMessage().thinking()).isNull();
+                        }
+                    });
+        }
+    }
+
+    @Test
+    void should_not_send_thinking_when_send_thinking_is_disabled() {
+        stubMessage();
+
+        contextRunner
+                .withPropertyValues(
+                        "langchain4j.anthropic.chat-model.base-url=" + baseUrl,
+                        "langchain4j.anthropic.chat-model.api-key=" + API_KEY,
+                        "langchain4j.anthropic.chat-model.model-name=" + MODEL_NAME,
+                        "langchain4j.anthropic.chat-model.max-tokens=20",
+                        "langchain4j.anthropic.chat-model.send-thinking=false"
+                )
+                .run(context -> {
+                    context.getBean(ChatModel.class).chat(requestExercisingEveryProperty());
+
+                    assertThat(WireMock.findAll(postRequestedFor(urlPathEqualTo(MESSAGES_PATH)))
+                                    .get(0)
+                                    .getBodyAsString())
+                            .doesNotContain("earlier thinking");
+                });
+    }
+
+    @Test
+    void should_bind_chat_model_timeout() {
+        WireMock.stubFor(post(urlPathEqualTo(MESSAGES_PATH)).willReturn(okJson("{}").withFixedDelay(3_000)));
+
+        contextRunner
+                .withPropertyValues(
+                        "langchain4j.anthropic.chat-model.base-url=" + baseUrl,
+                        "langchain4j.anthropic.chat-model.api-key=" + API_KEY,
+                        "langchain4j.anthropic.chat-model.model-name=" + MODEL_NAME,
+                        "langchain4j.anthropic.chat-model.max-tokens=20",
+                        "langchain4j.anthropic.chat-model.max-retries=0",
+                        "langchain4j.anthropic.chat-model.timeout=PT0.5S"
+                )
+                .run(context -> {
+                    ChatModel model = context.getBean(ChatModel.class);
+                    assertThatThrownBy(() -> model.chat("hi")).isInstanceOf(TimeoutException.class);
+                });
+    }
+
+    @Test
+    void should_bind_chat_model_max_retries() {
+        WireMock.stubFor(post(urlPathEqualTo(MESSAGES_PATH))
+                .willReturn(aResponse().withStatus(500).withBody("server error")));
+
+        contextRunner
+                .withPropertyValues(
+                        "langchain4j.anthropic.chat-model.base-url=" + baseUrl,
+                        "langchain4j.anthropic.chat-model.api-key=" + API_KEY,
+                        "langchain4j.anthropic.chat-model.model-name=" + MODEL_NAME,
+                        "langchain4j.anthropic.chat-model.max-tokens=20",
+                        "langchain4j.anthropic.chat-model.max-retries=2"
+                )
+                .run(context -> {
+                    ChatModel model = context.getBean(ChatModel.class);
+                    assertThatThrownBy(() -> model.chat("hi")).isInstanceOf(RuntimeException.class);
+
+                    // the initial attempt plus two retries
+                    assertThat(WireMock.findAll(postRequestedFor(urlPathEqualTo(MESSAGES_PATH)))).hasSize(3);
+                });
+    }
+
+    private static void stubMessage() {
+        WireMock.stubFor(post(urlPathEqualTo(MESSAGES_PATH)).willReturn(okJson(MESSAGE_RESPONSE)));
+    }
+
+    private static void stubStreamedMessage() {
+        WireMock.stubFor(post(urlPathEqualTo(MESSAGES_PATH)).willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/event-stream")
+                .withBody(MESSAGE_SSE)));
+    }
+
+    private static ChatResponse chat(StreamingChatModel model, ChatRequest request) throws Exception {
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+        model.chat(request, new StreamingChatResponseHandler() {
+
+            @Override
+            public void onPartialResponse(String partialResponse) {
+            }
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                future.complete(completeResponse);
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                future.completeExceptionally(error);
+            }
+        });
+        return future.get(30, SECONDS);
+    }
+}

--- a/langchain4j-anthropic-spring-boot4-starter/src/main/java/dev/langchain4j/anthropic/spring/AnthropicAutoConfiguration.java
+++ b/langchain4j-anthropic-spring-boot4-starter/src/main/java/dev/langchain4j/anthropic/spring/AnthropicAutoConfiguration.java
@@ -1,5 +1,8 @@
 package dev.langchain4j.anthropic.spring;
 
+import java.util.Collection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
 import dev.langchain4j.model.anthropic.AnthropicStreamingChatModel;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
@@ -14,6 +17,8 @@ import static dev.langchain4j.anthropic.spring.AnthropicProperties.PREFIX;
 @AutoConfiguration
 @EnableConfigurationProperties(AnthropicProperties.class)
 public class AnthropicAutoConfiguration {
+
+    private static final Logger log = LoggerFactory.getLogger(AnthropicAutoConfiguration.class);
 
     @Bean
     @ConditionalOnProperty(PREFIX + ".chat-model.api-key")
@@ -51,6 +56,9 @@ public class AnthropicAutoConfiguration {
     AnthropicStreamingChatModel anthropicStreamingChatModel(AnthropicProperties properties,
                                                             ObjectProvider<ChatModelListener> listeners) {
         AnthropicChatModelProperties chatModelProperties = properties.getStreamingChatModel();
+        warnIfSet(chatModelProperties.getMaxRetries(), "streaming-chat-model", "max-retries",
+                "a response that has already started streaming cannot be retried");
+
         return AnthropicStreamingChatModel.builder()
                 .baseUrl(chatModelProperties.getBaseUrl())
                 .apiKey(chatModelProperties.getApiKey())
@@ -62,6 +70,7 @@ public class AnthropicAutoConfiguration {
                 .topK(chatModelProperties.getTopK())
                 .maxTokens(chatModelProperties.getMaxTokens())
                 .stopSequences(chatModelProperties.getStopSequences())
+                .toolChoice(chatModelProperties.getToolChoice())
                 .cacheSystemMessages(chatModelProperties.getCacheSystemMessages())
                 .cacheTools(chatModelProperties.getCacheTools())
                 .thinkingType(chatModelProperties.getThinkingType())
@@ -75,4 +84,16 @@ public class AnthropicAutoConfiguration {
                 .listeners(listeners.orderedStream().toList())
                 .build();
     }
+
+    /**
+     * Some properties are shared between the sync and the streaming variants of a model, but the streaming model
+     * cannot honour all of them. Rather than silently ignoring such a property, say so once at startup.
+     */
+    private static void warnIfSet(Object value, String model, String property, String reason) {
+        boolean set = value instanceof Collection<?> collection ? !collection.isEmpty() : value != null;
+        if (set) {
+            log.warn("{}.{}.{} is set, but it is ignored: {}", PREFIX, model, property, reason);
+        }
+    }
+
 }

--- a/langchain4j-anthropic-spring-boot4-starter/src/test/java/dev/langchain4j/anthropic/spring/AnthropicIgnoredPropertyWarningTest.java
+++ b/langchain4j-anthropic-spring-boot4-starter/src/test/java/dev/langchain4j/anthropic/spring/AnthropicIgnoredPropertyWarningTest.java
@@ -1,0 +1,92 @@
+package dev.langchain4j.anthropic.spring;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The streaming chat model reuses the properties of its sync counterpart, but cannot honour all of them. Setting
+ * such a property has to be reported, otherwise it looks like it took effect.
+ */
+class AnthropicIgnoredPropertyWarningTest {
+
+    private ListAppender<ILoggingEvent> appender;
+    private ch.qos.logback.classic.Logger logger;
+
+    ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(AnthropicAutoConfiguration.class));
+
+    @BeforeEach
+    void setUp() {
+        logger = ((LoggerContext) LoggerFactory.getILoggerFactory()).getLogger(AnthropicAutoConfiguration.class);
+        appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(appender);
+    }
+
+    private List<String> warnings() {
+        return appender.list.stream()
+                .filter(event -> event.getLevel() == Level.WARN)
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+    }
+
+    @Test
+    void should_warn_when_streaming_chat_model_is_given_a_property_it_ignores() {
+        contextRunner
+                .withPropertyValues(
+                        "langchain4j.anthropic.streaming-chat-model.api-key=test-api-key",
+                        "langchain4j.anthropic.streaming-chat-model.model-name=claude-haiku-4-5-20251001",
+                        "langchain4j.anthropic.streaming-chat-model.max-retries=3"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(StreamingChatModel.class);
+
+                    assertThat(warnings()).anySatisfy(warning -> assertThat(warning)
+                            .contains("langchain4j.anthropic.streaming-chat-model.max-retries")
+                            .contains("ignored"));
+                });
+    }
+
+    @Test
+    void should_not_warn_when_the_ignored_property_is_not_set() {
+        contextRunner
+                .withPropertyValues(
+                        "langchain4j.anthropic.streaming-chat-model.api-key=test-api-key",
+                        "langchain4j.anthropic.streaming-chat-model.model-name=claude-haiku-4-5-20251001",
+                        "langchain4j.anthropic.streaming-chat-model.temperature=0.0"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(StreamingChatModel.class);
+                    assertThat(warnings()).isEmpty();
+                });
+    }
+
+    @Test
+    void should_not_warn_when_the_same_property_is_set_on_the_sync_model() {
+        contextRunner
+                .withPropertyValues(
+                        "langchain4j.anthropic.chat-model.api-key=test-api-key",
+                        "langchain4j.anthropic.chat-model.model-name=claude-haiku-4-5-20251001",
+                        "langchain4j.anthropic.chat-model.max-retries=3"
+                )
+                .run(context -> assertThat(warnings()).isEmpty());
+    }
+}

--- a/langchain4j-anthropic-spring-boot4-starter/src/test/java/dev/langchain4j/anthropic/spring/AnthropicPropertyBindingTest.java
+++ b/langchain4j-anthropic-spring-boot4-starter/src/test/java/dev/langchain4j/anthropic/spring/AnthropicPropertyBindingTest.java
@@ -1,0 +1,402 @@
+package dev.langchain4j.anthropic.spring;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.TimeoutException;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Verifies that every property this starter exposes actually reaches the Anthropic API, so that a typo in the
+ * auto-configuration cannot go unnoticed. The API is stubbed, so no API key and no network access are required.
+ * <p>
+ * A few properties cannot be observed on the wire and are covered by their effect instead: {@code timeout} and
+ * {@code max-retries} by how the client behaves, and {@code return-thinking} by what the model reports.
+ * <p>
+ * Two properties are deliberately not asserted: {@code log-requests} and {@code log-responses} only change what is
+ * written to the log, so they are merely set here to make sure they bind. Note also that {@code max-retries} exists
+ * on the streaming chat model properties but is not supported by
+ * {@link dev.langchain4j.model.anthropic.AnthropicStreamingChatModel}, so it has no effect there.
+ * <p>
+ * {@code base-url} needs no assertion of its own: nothing below would reach the stub server without it.
+ */
+@WireMockTest
+class AnthropicPropertyBindingTest {
+
+    private static final String API_KEY = "test-api-key";
+    private static final String MODEL_NAME = "claude-haiku-4-5-20251001";
+    private static final String MESSAGES_PATH = "/v1/messages";
+
+    private static final String MESSAGE_RESPONSE =
+            """
+            {
+              "id": "msg_1",
+              "type": "message",
+              "role": "assistant",
+              "model": "claude-haiku-4-5-20251001",
+              "content": [{"type": "text", "text": "ok"}],
+              "stop_reason": "end_turn",
+              "usage": {"input_tokens": 10, "output_tokens": 1}
+            }
+            """;
+
+    private static final String THINKING_RESPONSE =
+            """
+            {
+              "id": "msg_1",
+              "type": "message",
+              "role": "assistant",
+              "model": "claude-haiku-4-5-20251001",
+              "content": [
+                {"type": "thinking", "thinking": "let me think", "signature": "sig"},
+                {"type": "text", "text": "ok"}
+              ],
+              "stop_reason": "end_turn",
+              "usage": {"input_tokens": 10, "output_tokens": 1}
+            }
+            """;
+
+    private static final String MESSAGE_SSE =
+            """
+            event: message_start
+            data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant",\
+            "model":"claude-haiku-4-5-20251001","content":[],"usage":{"input_tokens":10,"output_tokens":0}}}
+
+            event: content_block_start
+            data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}
+
+            event: content_block_stop
+            data: {"type":"content_block_stop","index":0}
+
+            event: message_delta
+            data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}
+
+            event: message_stop
+            data: {"type":"message_stop"}
+
+            """;
+
+    private static final String THINKING_SSE =
+            """
+            event: message_start
+            data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant",\
+            "model":"claude-haiku-4-5-20251001","content":[],"usage":{"input_tokens":10,"output_tokens":0}}}
+
+            event: content_block_start
+            data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"let me think"}}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig"}}
+
+            event: content_block_stop
+            data: {"type":"content_block_stop","index":0}
+
+            event: content_block_start
+            data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"ok"}}
+
+            event: content_block_stop
+            data: {"type":"content_block_stop","index":1}
+
+            event: message_delta
+            data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}
+
+            event: message_stop
+            data: {"type":"message_stop"}
+
+            """;
+
+    private String baseUrl;
+
+    ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(AnthropicAutoConfiguration.class));
+
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wireMock) {
+        baseUrl = wireMock.getHttpBaseUrl() + "/v1";
+    }
+
+    private String[] allChatModelProperties(String prefix) {
+        return new String[] {
+            prefix + ".base-url=" + baseUrl,
+            prefix + ".api-key=" + API_KEY,
+            prefix + ".version=2023-06-01",
+            prefix + ".beta=tools-2024-04-04",
+            prefix + ".model-name=" + MODEL_NAME,
+            prefix + ".temperature=0.3",
+            prefix + ".top-p=0.4",
+            prefix + ".top-k=5",
+            prefix + ".max-tokens=11",
+            prefix + ".stop-sequences=alpha,beta",
+            prefix + ".tool-choice=REQUIRED",
+            prefix + ".cache-system-messages=true",
+            prefix + ".cache-tools=true",
+            prefix + ".thinking-type=enabled",
+            prefix + ".thinking-budget-tokens=1024",
+            prefix + ".send-thinking=true",
+            prefix + ".custom-parameters.custom-key=custom-value",
+            prefix + ".timeout=PT30S",
+            prefix + ".log-requests=true",
+            prefix + ".log-responses=true"
+        };
+    }
+
+    private static void assertAllChatModelPropertiesOnTheWire() {
+        WireMock.verify(postRequestedFor(urlPathEqualTo(MESSAGES_PATH))
+                .withHeader("x-api-key", equalTo(API_KEY))
+                .withHeader("anthropic-version", equalTo("2023-06-01"))
+                .withHeader("anthropic-beta", equalTo("tools-2024-04-04"))
+                .withRequestBody(matchingJsonPath("$.model", equalTo(MODEL_NAME)))
+                .withRequestBody(matchingJsonPath("$.temperature", equalTo("0.3")))
+                .withRequestBody(matchingJsonPath("$.top_p", equalTo("0.4")))
+                .withRequestBody(matchingJsonPath("$.top_k", equalTo("5")))
+                .withRequestBody(matchingJsonPath("$.max_tokens", equalTo("11")))
+                .withRequestBody(matchingJsonPath("$.stop_sequences[0]", equalTo("alpha")))
+                .withRequestBody(matchingJsonPath("$.stop_sequences[1]", equalTo("beta")))
+                .withRequestBody(matchingJsonPath("$.tool_choice.type", equalTo("any")))
+                .withRequestBody(matchingJsonPath("$.system[0].cache_control.type", equalTo("ephemeral")))
+                .withRequestBody(matchingJsonPath("$.tools[0].cache_control.type", equalTo("ephemeral")))
+                .withRequestBody(matchingJsonPath("$.thinking.type", equalTo("enabled")))
+                .withRequestBody(matchingJsonPath("$.thinking.budget_tokens", equalTo("1024")))
+                .withRequestBody(matchingJsonPath("$.custom-key", equalTo("custom-value"))));
+    }
+
+    /**
+     * Carries everything the properties above need in order to show up: a system message for
+     * {@code cache-system-messages}, a tool for {@code cache-tools} and {@code tool-choice}, and an earlier reply
+     * with thinking for {@code send-thinking}.
+     */
+    private static ChatRequest requestExercisingEveryProperty() {
+        return ChatRequest.builder()
+                .messages(
+                        SystemMessage.from("be brief"),
+                        UserMessage.from("hi"),
+                        AiMessage.builder()
+                                .text("earlier answer")
+                                .thinking("earlier thinking")
+                                .attributes(Map.of("thinking_signature", "sig"))
+                                .build(),
+                        UserMessage.from("and now?"))
+                .toolSpecifications(ToolSpecification.builder()
+                        .name("getCurrentDate")
+                        .description("get the current date")
+                        .build())
+                .build();
+    }
+
+    @Test
+    void should_bind_all_chat_model_properties() {
+        stubMessage();
+
+        contextRunner
+                .withPropertyValues(allChatModelProperties("langchain4j.anthropic.chat-model"))
+                .run(context -> {
+                    context.getBean(ChatModel.class).chat(requestExercisingEveryProperty());
+
+                    assertAllChatModelPropertiesOnTheWire();
+
+                    // send-thinking: the thinking of the earlier reply is sent back
+                    assertThat(WireMock.findAll(postRequestedFor(urlPathEqualTo(MESSAGES_PATH)))
+                                    .get(0)
+                                    .getBodyAsString())
+                            .contains("earlier thinking");
+                });
+    }
+
+    @Test
+    void should_bind_all_streaming_chat_model_properties() {
+        stubStreamedMessage();
+
+        contextRunner
+                .withPropertyValues(allChatModelProperties("langchain4j.anthropic.streaming-chat-model"))
+                .run(context -> {
+                    chat(context.getBean(StreamingChatModel.class), requestExercisingEveryProperty());
+
+                    assertAllChatModelPropertiesOnTheWire();
+                });
+    }
+
+    @Test
+    void should_bind_chat_model_return_thinking() {
+        WireMock.stubFor(post(urlPathEqualTo(MESSAGES_PATH)).willReturn(okJson(THINKING_RESPONSE)));
+
+        for (boolean returnThinking : new boolean[] {true, false}) {
+            contextRunner
+                    .withPropertyValues(
+                            "langchain4j.anthropic.chat-model.base-url=" + baseUrl,
+                            "langchain4j.anthropic.chat-model.api-key=" + API_KEY,
+                            "langchain4j.anthropic.chat-model.model-name=" + MODEL_NAME,
+                            "langchain4j.anthropic.chat-model.max-tokens=20",
+                            "langchain4j.anthropic.chat-model.return-thinking=" + returnThinking
+                    )
+                    .run(context -> {
+                        ChatResponse response = context.getBean(ChatModel.class)
+                                .chat(ChatRequest.builder().messages(UserMessage.from("hi")).build());
+
+                        if (returnThinking) {
+                            assertThat(response.aiMessage().thinking()).isEqualTo("let me think");
+                        } else {
+                            assertThat(response.aiMessage().thinking()).isNull();
+                        }
+                    });
+        }
+    }
+
+    @Test
+    void should_bind_streaming_chat_model_return_thinking() throws Exception {
+        WireMock.stubFor(post(urlPathEqualTo(MESSAGES_PATH)).willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/event-stream")
+                .withBody(THINKING_SSE)));
+
+        for (boolean returnThinking : new boolean[] {true, false}) {
+            contextRunner
+                    .withPropertyValues(
+                            "langchain4j.anthropic.streaming-chat-model.base-url=" + baseUrl,
+                            "langchain4j.anthropic.streaming-chat-model.api-key=" + API_KEY,
+                            "langchain4j.anthropic.streaming-chat-model.model-name=" + MODEL_NAME,
+                            "langchain4j.anthropic.streaming-chat-model.max-tokens=20",
+                            "langchain4j.anthropic.streaming-chat-model.return-thinking=" + returnThinking
+                    )
+                    .run(context -> {
+                        ChatResponse response = chat(context.getBean(StreamingChatModel.class),
+                                ChatRequest.builder().messages(UserMessage.from("hi")).build());
+
+                        if (returnThinking) {
+                            assertThat(response.aiMessage().thinking()).isEqualTo("let me think");
+                        } else {
+                            assertThat(response.aiMessage().thinking()).isNull();
+                        }
+                    });
+        }
+    }
+
+    @Test
+    void should_not_send_thinking_when_send_thinking_is_disabled() {
+        stubMessage();
+
+        contextRunner
+                .withPropertyValues(
+                        "langchain4j.anthropic.chat-model.base-url=" + baseUrl,
+                        "langchain4j.anthropic.chat-model.api-key=" + API_KEY,
+                        "langchain4j.anthropic.chat-model.model-name=" + MODEL_NAME,
+                        "langchain4j.anthropic.chat-model.max-tokens=20",
+                        "langchain4j.anthropic.chat-model.send-thinking=false"
+                )
+                .run(context -> {
+                    context.getBean(ChatModel.class).chat(requestExercisingEveryProperty());
+
+                    assertThat(WireMock.findAll(postRequestedFor(urlPathEqualTo(MESSAGES_PATH)))
+                                    .get(0)
+                                    .getBodyAsString())
+                            .doesNotContain("earlier thinking");
+                });
+    }
+
+    @Test
+    void should_bind_chat_model_timeout() {
+        WireMock.stubFor(post(urlPathEqualTo(MESSAGES_PATH)).willReturn(okJson("{}").withFixedDelay(3_000)));
+
+        contextRunner
+                .withPropertyValues(
+                        "langchain4j.anthropic.chat-model.base-url=" + baseUrl,
+                        "langchain4j.anthropic.chat-model.api-key=" + API_KEY,
+                        "langchain4j.anthropic.chat-model.model-name=" + MODEL_NAME,
+                        "langchain4j.anthropic.chat-model.max-tokens=20",
+                        "langchain4j.anthropic.chat-model.max-retries=0",
+                        "langchain4j.anthropic.chat-model.timeout=PT0.5S"
+                )
+                .run(context -> {
+                    ChatModel model = context.getBean(ChatModel.class);
+                    assertThatThrownBy(() -> model.chat("hi")).isInstanceOf(TimeoutException.class);
+                });
+    }
+
+    @Test
+    void should_bind_chat_model_max_retries() {
+        WireMock.stubFor(post(urlPathEqualTo(MESSAGES_PATH))
+                .willReturn(aResponse().withStatus(500).withBody("server error")));
+
+        contextRunner
+                .withPropertyValues(
+                        "langchain4j.anthropic.chat-model.base-url=" + baseUrl,
+                        "langchain4j.anthropic.chat-model.api-key=" + API_KEY,
+                        "langchain4j.anthropic.chat-model.model-name=" + MODEL_NAME,
+                        "langchain4j.anthropic.chat-model.max-tokens=20",
+                        "langchain4j.anthropic.chat-model.max-retries=2"
+                )
+                .run(context -> {
+                    ChatModel model = context.getBean(ChatModel.class);
+                    assertThatThrownBy(() -> model.chat("hi")).isInstanceOf(RuntimeException.class);
+
+                    // the initial attempt plus two retries
+                    assertThat(WireMock.findAll(postRequestedFor(urlPathEqualTo(MESSAGES_PATH)))).hasSize(3);
+                });
+    }
+
+    private static void stubMessage() {
+        WireMock.stubFor(post(urlPathEqualTo(MESSAGES_PATH)).willReturn(okJson(MESSAGE_RESPONSE)));
+    }
+
+    private static void stubStreamedMessage() {
+        WireMock.stubFor(post(urlPathEqualTo(MESSAGES_PATH)).willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/event-stream")
+                .withBody(MESSAGE_SSE)));
+    }
+
+    private static ChatResponse chat(StreamingChatModel model, ChatRequest request) throws Exception {
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+        model.chat(request, new StreamingChatResponseHandler() {
+
+            @Override
+            public void onPartialResponse(String partialResponse) {
+            }
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                future.complete(completeResponse);
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                future.completeExceptionally(error);
+            }
+        });
+        return future.get(30, SECONDS);
+    }
+}


### PR DESCRIPTION
## Motivation

  The same treatment the OpenAI starters got in #205, applied to Anthropic.

  `ChatModelProperties` declares 22 properties and is shared between `chat-model` and `streaming-chat-model`, so there are 44 property slots to get right. Nothing verified that any of them reached the API — a
  typo in the auto-configuration would have gone unnoticed.

  This adds a test that sets **every** property the starter exposes and asserts it arrives at the Anthropic API, with the API stubbed by WireMock so it runs on every PR without an API key.

  As with OpenAI, the assertions were written from a real captured request rather than from the docs. That matters here, because several Anthropic properties do not appear as top-level fields:

  | Property | Where it actually shows up |
  | --- | --- |
  | `api-key`, `version`, `beta` | `x-api-key`, `anthropic-version`, `anthropic-beta` headers |
  | `tool-choice=REQUIRED` | `$.tool_choice.type` = `any` |
  | `cache-system-messages` | `$.system[0].cache_control.type` |
  | `cache-tools` | `$.tools[0].cache_control.type` |
  | `thinking-type`, `thinking-budget-tokens` | `$.thinking.type`, `$.thinking.budget_tokens` |
  | `custom-parameters` | merged into the root of the request body |

  Because of that, the shared request in these tests deliberately carries a system message, a tool, and an earlier reply containing thinking. Without all three, several of those properties would have nothing to
  attach to and the assertions would pass vacuously.

  ## Coverage

  **43 of 44 property slots.**

  Properties that are not visible in a request body are covered by their effect instead:

  | Property | Verified by |
  | --- | --- |
  | `timeout` | a delayed stub, expecting `TimeoutException` |
  | `max-retries` | a 500 stub, asserting exactly 1 + N requests |
  | `return-thinking` | `aiMessage().thinking()`, for both `true` and `false`, sync and streaming |
  | `send-thinking` | whether an earlier reply's thinking is sent back |

  `base-url` needs no assertion of its own — nothing would reach the stub server without it. `log-requests` and `log-responses` are set but not asserted, since they only change what is written to the log.

  The remaining slot is `streaming-chat-model.max-retries`, which cannot work at all; see below.

  ## The bug this uncovered
  `langchain4j.anthropic.streaming-chat-model.tool-choice` was declared, is supported by `AnthropicStreamingChatModel.Builder`, and was never passed to the builder. The sync model honoured it; the streaming
  model silently ignored it.

  This is the same defect that #205 found in the OpenAI starter, where `streaming-chat-model.strict-json-schema` was declared and dropped in exactly the same way: a property wired into the sync builder and
  forgotten in the streaming one. It is worth expecting in the remaining providers too.

  ## A property that cannot be honoured is now reported

  `AnthropicStreamingChatModel` has no `maxRetries` — a response that has already started streaming cannot be retried — but the property exists, because the streaming model reuses the properties of the sync one.
  Setting it used to do nothing at all. It now produces a warning at startup:

  ```
  langchain4j.anthropic.streaming-chat-model.max-retries is set, but it is ignored:
  a response that has already started streaming cannot be retried
  ```

  Covered by tests asserting the warning appears, stays silent when the property is unset, and stays silent when the same property is set on the sync model, where it does work.

  A warning rather than a startup failure, for the same reason as in #205: failing would break applications that have the property set today, for the sake of something that is merely wasteful. The real fix is to
  stop sharing one properties class between the sync and streaming variants, which is a breaking change and belongs in 2.0.

  ## Behaviour changes

  `langchain4j.anthropic.streaming-chat-model.tool-choice` now takes effect. If you have it set and were relying on the streaming model ignoring it, your requests change: the model will now be constrained to the
  tool choice you configured.

  Setting `streaming-chat-model.max-retries` now logs a warning. No API is added, removed or changed.

  ## Notes

  Unlike the OpenAI starter, this one does not swap in `SpringRestClient`, so it uses LangChain4j's own JDK HTTP client, which already reports read timeouts as `TimeoutException`. None of the HTTP client changes
  from #205 are needed here.

  Test counts: 12 per module, up from 2.