### PR TITLE
Reactor support for the non-blocking AI Service modes, and Spring's executor for offloaded work

### DIFF
--- a/langchain4j-reactor/src/main/java/dev/langchain4j/reactor/FluxPublisherAdapter.java
+++ b/langchain4j-reactor/src/main/java/dev/langchain4j/reactor/FluxPublisherAdapter.java
@@ -1,0 +1,38 @@
+package dev.langchain4j.reactor;
+
+import dev.langchain4j.service.AiServiceStreamingEvent;
+import dev.langchain4j.spi.services.PublisherAdapter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.concurrent.Flow;
+import org.reactivestreams.FlowAdapters;
+import reactor.core.publisher.Flux;
+
+/**
+ * Adapts the {@link Flow.Publisher} produced by a non-blocking streaming AI Service to a Reactor {@link Flux}, so
+ * an AI Service method can be declared to return {@code Flux<AiServiceStreamingEvent>}.
+ * <p>
+ * <b>{@code Flux<String>} is deliberately not handled here.</b> It is already served by
+ * {@link TokenStreamToFluxAdapter} over the callback-based {@code TokenStream}, which works with every provider.
+ * The non-blocking path only works with providers that implement the reactive chat SPI, and {@code AiServices}
+ * checks for a {@link PublisherAdapter} before it checks for a {@code TokenStream} adapter — so claiming
+ * {@code Flux<String>} here would silently move every existing {@code Flux<String>} method onto the non-blocking
+ * path and break it on every provider that has not opted in.
+ *
+ * @see TokenStreamToFluxAdapter
+ */
+public class FluxPublisherAdapter implements PublisherAdapter {
+
+    @Override
+    public boolean canAdapt(Type type) {
+        return type instanceof ParameterizedType parameterizedType
+                && parameterizedType.getRawType() == Flux.class
+                && parameterizedType.getActualTypeArguments().length == 1
+                && parameterizedType.getActualTypeArguments()[0] == AiServiceStreamingEvent.class;
+    }
+
+    @Override
+    public Object fromPublisher(Type type, Flow.Publisher<?> publisher) {
+        return Flux.from(FlowAdapters.toPublisher(publisher));
+    }
+}

--- a/langchain4j-reactor/src/main/java/dev/langchain4j/reactor/MonoCompletableFutureAdapter.java
+++ b/langchain4j-reactor/src/main/java/dev/langchain4j/reactor/MonoCompletableFutureAdapter.java
@@ -1,0 +1,34 @@
+package dev.langchain4j.reactor;
+
+import dev.langchain4j.spi.services.CompletableFutureAdapter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+import reactor.core.publisher.Mono;
+
+/**
+ * Adapts between a {@link CompletableFuture} and a Reactor {@link Mono}, so an AI Service method - or a
+ * {@code @Tool} method - can be declared to return {@code Mono<T>} and take part in the non-blocking path.
+ * <p>
+ * Subscribing to the returned {@link Mono} does not start the work: the AI Service call is already in flight by
+ * the time the {@link Mono} exists, so this is a hot source. Cancelling the subscription cancels the underlying
+ * future, which the AI Service treats as a request to stop the interaction.
+ */
+public class MonoCompletableFutureAdapter implements CompletableFutureAdapter {
+
+    @Override
+    public boolean canAdapt(Type type) {
+        return type instanceof ParameterizedType parameterizedType
+                && parameterizedType.getRawType() == Mono.class;
+    }
+
+    @Override
+    public CompletableFuture<?> toCompletableFuture(Object asyncValue) {
+        return ((Mono<?>) asyncValue).toFuture();
+    }
+
+    @Override
+    public Object fromCompletableFuture(Type type, CompletableFuture<?> future) {
+        return Mono.fromFuture(() -> future).doOnCancel(() -> future.cancel(true));
+    }
+}

--- a/langchain4j-reactor/src/main/resources/META-INF/services/dev.langchain4j.spi.services.CompletableFutureAdapter
+++ b/langchain4j-reactor/src/main/resources/META-INF/services/dev.langchain4j.spi.services.CompletableFutureAdapter
@@ -1,0 +1,1 @@
+dev.langchain4j.reactor.MonoCompletableFutureAdapter

--- a/langchain4j-reactor/src/main/resources/META-INF/services/dev.langchain4j.spi.services.PublisherAdapter
+++ b/langchain4j-reactor/src/main/resources/META-INF/services/dev.langchain4j.spi.services.PublisherAdapter
@@ -1,0 +1,1 @@
+dev.langchain4j.reactor.FluxPublisherAdapter

--- a/langchain4j-reactor/src/test/java/dev/langchain4j/reactor/AiServiceWithReactorNonBlockingTest.java
+++ b/langchain4j-reactor/src/test/java/dev/langchain4j/reactor/AiServiceWithReactorNonBlockingTest.java
@@ -1,0 +1,117 @@
+package dev.langchain4j.reactor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatModelStreamingEvent;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.CompleteResponse;
+import dev.langchain4j.model.chat.response.PartialResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import java.util.ArrayList;
+import java.util.concurrent.Flow;
+import org.reactivestreams.FlowAdapters;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.mock.ChatModelMock;
+import dev.langchain4j.service.AiServiceStreamingEvent;
+import dev.langchain4j.service.AiServices;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * The Reactor bindings of the non-blocking AI Service modes: {@code Mono<T>} over the {@code CompletableFuture}
+ * path, and {@code Flux<AiServiceStreamingEvent>} over the reactive publisher path.
+ */
+class AiServiceWithReactorNonBlockingTest {
+
+    interface Assistant {
+
+        Mono<String> answer(String userMessage);
+
+        Flux<AiServiceStreamingEvent> events(String userMessage);
+    }
+
+    @Test
+    void should_return_a_Mono_from_the_non_blocking_path() {
+        ChatModel model = ChatModelMock.thatAlwaysResponds("Hello");
+
+        Assistant assistant =
+                AiServices.builder(Assistant.class).chatModel(model).build();
+
+        StepVerifier.create(assistant.answer("Hi")).expectNext("Hello").verifyComplete();
+    }
+
+    @Test
+    void should_stream_events_as_a_Flux() {
+        StreamingChatModel model = reactiveModel("H", "e", "l", "l", "o");
+
+        Assistant assistant =
+                AiServices.builder(Assistant.class).streamingChatModel(model).build();
+
+        List<AiServiceStreamingEvent> events =
+                assistant.events("Hi").collectList().block();
+
+        assertThat(events).isNotEmpty();
+        assertThat(events).last().isInstanceOf(AiServiceStreamingEvent.FinalResponseEvent.class);
+        String text = events.stream()
+                .filter(AiServiceStreamingEvent.PartialResponseEvent.class::isInstance)
+                .map(e -> ((AiServiceStreamingEvent.PartialResponseEvent) e)
+                        .partialResponse()
+                        .text())
+                .reduce("", String::concat);
+        assertThat(text).isEqualTo("Hello");
+    }
+
+    @Test
+    void Flux_of_String_still_uses_the_TokenStream_path_so_every_provider_keeps_working() throws Exception {
+        // FluxPublisherAdapter deliberately does not claim Flux<String>: AiServices consults a PublisherAdapter
+        // before a TokenStreamAdapter, so claiming it would move existing Flux<String> methods onto the
+        // non-blocking path and break them on providers that have not implemented the reactive chat SPI.
+        FluxPublisherAdapter adapter = new FluxPublisherAdapter();
+
+        assertThat(adapter.canAdapt(Returns.class.getMethod("text").getGenericReturnType()))
+                .isFalse();
+        assertThat(adapter.canAdapt(Returns.class.getMethod("events").getGenericReturnType()))
+                .isTrue();
+    }
+
+
+    /**
+     * A minimal {@link StreamingChatModel} that implements the reactive SPI, emitting one
+     * {@code PartialResponse} per token and then the terminal {@code CompleteResponse}. The shared
+     * {@code StreamingChatModelMock} only implements the handler-based API, so a non-blocking AI Service
+     * correctly refuses it with {@code AsyncNotSupportedException}.
+     */
+    private static StreamingChatModel reactiveModel(String... tokens) {
+        return new StreamingChatModel() {
+
+            @Override
+            public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Flow.Publisher<ChatModelStreamingEvent> doChat(ChatRequest chatRequest) {
+                List<ChatModelStreamingEvent> events = new ArrayList<>();
+                for (String token : tokens) {
+                    events.add(new PartialResponse(token));
+                }
+                events.add(new CompleteResponse(ChatResponse.builder()
+                        .aiMessage(AiMessage.from(String.join("", tokens)))
+                        .build()));
+                return FlowAdapters.toFlowPublisher(Flux.fromIterable(events));
+            }
+        };
+    }
+
+    interface Returns {
+        Flux<String> text();
+
+        Flux<AiServiceStreamingEvent> events();
+    }
+}

--- a/langchain4j-reactor/src/test/java/dev/langchain4j/reactor/AiServiceWithReactorRagMemoryGuardrailsTest.java
+++ b/langchain4j-reactor/src/test/java/dev/langchain4j/reactor/AiServiceWithReactorRagMemoryGuardrailsTest.java
@@ -1,0 +1,196 @@
+package dev.langchain4j.reactor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.guardrail.InputGuardrailException;
+import dev.langchain4j.guardrail.InputGuardrail;
+import dev.langchain4j.guardrail.InputGuardrailRequest;
+import dev.langchain4j.guardrail.InputGuardrailResult;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.service.guardrail.InputGuardrails;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.rag.DefaultRetrievalAugmentor;
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import dev.langchain4j.rag.query.Query;
+import dev.langchain4j.service.AiServices;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * RAG, chat memory and guardrails through the Reactor bindings. Each is covered both where it works and where it
+ * refuses: on the non-blocking path a component that has not implemented its asynchronous counterpart fails loudly
+ * rather than blocking a thread, and that is what a Spring user will actually meet.
+ */
+class AiServiceWithReactorRagMemoryGuardrailsTest {
+
+    interface Assistant {
+        Mono<String> answer(String userMessage);
+    }
+
+    /** Records what the model was asked, so a test can assert on memory and retrieved content. */
+    static class RecordingModel implements ChatModel {
+        final List<ChatRequest> requests = new CopyOnWriteArrayList<>();
+
+        @Override
+        public CompletableFuture<ChatResponse> doChatAsync(ChatRequest chatRequest) {
+            return CompletableFuture.completedFuture(doChat(chatRequest));
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            requests.add(chatRequest);
+            return ChatResponse.builder().aiMessage(AiMessage.from("ok")).build();
+        }
+    }
+
+    // ---------- chat memory ----------
+
+    @Test
+    void chat_memory_accumulates_across_Mono_calls() {
+        RecordingModel model = new RecordingModel();
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                // MessageWindowChatMemory implements addAsync/messagesAsync, so it works on the non-blocking path
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .build();
+
+        assistant.answer("first").block();
+        assistant.answer("second").block();
+
+        // second request carries the first exchange: user, ai, user
+        assertThat(model.requests).hasSize(2);
+        assertThat(model.requests.get(0).messages()).hasSize(1);
+        assertThat(model.requests.get(1).messages()).hasSize(3);
+    }
+
+    // ---------- RAG ----------
+
+    @Test
+    void a_retriever_that_implements_retrieveAsync_augments_a_Mono_call() {
+        RecordingModel model = new RecordingModel();
+        ContentRetriever asyncRetriever = new ContentRetriever() {
+
+            @Override
+            public CompletableFuture<List<Content>> retrieveAsync(Query query) {
+                return CompletableFuture.completedFuture(List.of(Content.from(TextSegment.from("Munich is sunny"))));
+            }
+
+            @Override
+            public List<Content> retrieve(Query query) {
+                throw new UnsupportedOperationException("the async path must not call the blocking one");
+            }
+        };
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .contentRetriever(asyncRetriever)
+                .build();
+
+        StepVerifier.create(assistant.answer("weather?")).expectNext("ok").verifyComplete();
+        assertThat(model.requests.get(0).messages().get(0).toString()).contains("Munich is sunny");
+    }
+
+    @Test
+    void a_blocking_only_retriever_fails_loudly_unless_offloading_is_enabled() {
+        ContentRetriever blockingOnly = query -> List.of(Content.from(TextSegment.from("Munich is sunny")));
+
+        Assistant refuses = AiServices.builder(Assistant.class)
+                .chatModel(new RecordingModel())
+                .contentRetriever(blockingOnly)
+                .build();
+
+        StepVerifier.create(refuses.answer("weather?"))
+                // the augmentor re-reports the marker as its parent type, adding guidance. Catching
+                // UnsupportedFeatureException covers both flavours, which is why AsyncNotSupportedException
+                // extends it.
+                .expectErrorSatisfies(error -> assertThat(error)
+                        .isInstanceOf(UnsupportedFeatureException.class)
+                        .hasMessageContaining("retrieveAsync")
+                        .hasMessageContaining("offloadBlocking(true)"))
+                .verify();
+
+        RecordingModel model = new RecordingModel();
+        Assistant offloads = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .retrievalAugmentor(DefaultRetrievalAugmentor.builder()
+                        .contentRetriever(blockingOnly)
+                        .offloadBlocking(true)
+                        .build())
+                .build();
+
+        StepVerifier.create(offloads.answer("weather?")).expectNext("ok").verifyComplete();
+        assertThat(model.requests.get(0).messages().get(0).toString()).contains("Munich is sunny");
+    }
+
+    // ---------- guardrails ----------
+
+    public static class AsyncGuardrail implements InputGuardrail {
+
+        static final List<String> seen = new CopyOnWriteArrayList<>();
+
+        @Override
+        public CompletableFuture<InputGuardrailResult> validateAsync(InputGuardrailRequest request) {
+            seen.add(request.userMessage().singleText());
+            return CompletableFuture.completedFuture(success());
+        }
+
+        @Override
+        public InputGuardrailResult validate(UserMessage userMessage) {
+            throw new UnsupportedOperationException("the async path must not call the blocking one");
+        }
+    }
+
+    public static class BlockingOnlyGuardrail implements InputGuardrail {
+
+        @Override
+        public InputGuardrailResult validate(UserMessage userMessage) {
+            return success();
+        }
+    }
+
+    interface AsyncGuarded {
+        @InputGuardrails(AsyncGuardrail.class)
+        Mono<String> answer(String userMessage);
+    }
+
+    interface BlockingGuarded {
+        @InputGuardrails(BlockingOnlyGuardrail.class)
+        Mono<String> answer(String userMessage);
+    }
+
+    @Test
+    void a_guardrail_that_implements_validateAsync_runs_on_a_Mono_call() {
+        AsyncGuardrail.seen.clear();
+        AsyncGuarded assistant = AiServices.builder(AsyncGuarded.class)
+                .chatModel(new RecordingModel())
+                .build();
+
+        StepVerifier.create(assistant.answer("hi")).expectNext("ok").verifyComplete();
+        assertThat(AsyncGuardrail.seen).containsExactly("hi");
+    }
+
+    @Test
+    void a_blocking_only_guardrail_fails_loudly_with_actionable_guidance() {
+        BlockingGuarded assistant = AiServices.builder(BlockingGuarded.class)
+                .chatModel(new RecordingModel())
+                .build();
+
+        StepVerifier.create(assistant.answer("hi"))
+                .expectErrorSatisfies(error -> assertThat(error)
+                        .isInstanceOf(InputGuardrailException.class)
+                        .hasMessageContaining("does not implement validateAsync()")
+                        .hasMessageContaining("override validateAsync()"))
+                .verify();
+    }
+}

--- a/langchain4j-reactor/src/test/java/dev/langchain4j/reactor/AiServiceWithReactorToolsTest.java
+++ b/langchain4j-reactor/src/test/java/dev/langchain4j/reactor/AiServiceWithReactorToolsTest.java
@@ -1,0 +1,153 @@
+package dev.langchain4j.reactor;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.AiServices;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * Tools, cancellation and error propagation through the Reactor bindings of the non-blocking AI Service modes.
+ * These cover the parts of {@link MonoCompletableFutureAdapter} that the adapter's own javadoc claims but the
+ * type-level tests do not reach: a {@code Mono}-returning {@code @Tool}, and cancellation reaching the future.
+ */
+class AiServiceWithReactorToolsTest {
+
+    interface Assistant {
+        Mono<String> answer(String userMessage);
+    }
+
+    static class SyncTools {
+        final List<String> invoked = new CopyOnWriteArrayList<>();
+
+        @Tool("Returns the weather in a given city")
+        String getWeather(String city) {
+            invoked.add(city);
+            return "sunny";
+        }
+    }
+
+    static class MonoTools {
+        final List<String> invoked = new CopyOnWriteArrayList<>();
+
+        @Tool("Returns the weather in a given city")
+        Mono<String> getWeather(String city) {
+            invoked.add(city);
+            return Mono.just("sunny");
+        }
+    }
+
+    @Test
+    void a_blocking_tool_runs_during_a_Mono_returning_ai_service_call() {
+        SyncTools tools = new SyncTools();
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(toolThenAnswer())
+                .tools(tools)
+                .build();
+
+        StepVerifier.create(assistant.answer("What is the weather in Munich?"))
+                .expectNext("It is sunny")
+                .verifyComplete();
+        assertThat(tools.invoked).containsExactly("Munich");
+    }
+
+    @Test
+    void a_Mono_returning_tool_runs_during_a_Mono_returning_ai_service_call() {
+        // the claim MonoCompletableFutureAdapter.toCompletableFuture makes: a @Tool may return a Mono
+        MonoTools tools = new MonoTools();
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(toolThenAnswer())
+                .tools(tools)
+                .build();
+
+        StepVerifier.create(assistant.answer("What is the weather in Munich?"))
+                .expectNext("It is sunny")
+                .verifyComplete();
+        assertThat(tools.invoked).containsExactly("Munich");
+    }
+
+    @Test
+    void a_model_failure_surfaces_as_a_Mono_error() {
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(new ChatModel() {
+                    @Override
+                    public java.util.concurrent.CompletableFuture<ChatResponse> doChatAsync(ChatRequest chatRequest) {
+                        return java.util.concurrent.CompletableFuture.failedFuture(new IllegalStateException("boom"));
+                    }
+
+                    @Override
+                    public ChatResponse doChat(ChatRequest chatRequest) {
+                        throw new IllegalStateException("boom");
+                    }
+                })
+                .build();
+
+        StepVerifier.create(assistant.answer("hi"))
+                // the model's failure reaches the subscriber unwrapped, not buried in a CompletionException
+                .expectErrorSatisfies(error -> assertThat(error)
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessage("boom"))
+                .verify(Duration.ofSeconds(10));
+    }
+
+    @Test
+    void cancelling_the_Mono_cancels_the_underlying_future() {
+        java.util.concurrent.CompletableFuture<String> future = new java.util.concurrent.CompletableFuture<>();
+
+        Mono<?> mono = (Mono<?>) new MonoCompletableFutureAdapter()
+                .fromCompletableFuture(null, future);
+
+        mono.subscribe().dispose();
+
+        assertThat(future).isCancelled();
+    }
+
+    @Test
+    void a_Mono_tool_value_is_normalized_to_a_CompletableFuture() throws Exception {
+        Object value = new MonoCompletableFutureAdapter()
+                .toCompletableFuture(Mono.just("sunny"))
+                .get(5, SECONDS);
+
+        assertThat(value).isEqualTo("sunny");
+    }
+
+    /** Answers the first request with a tool call, the second with the final text. */
+    private static ChatModel toolThenAnswer() {
+        AtomicInteger calls = new AtomicInteger();
+        return new ChatModel() {
+            @Override
+            public java.util.concurrent.CompletableFuture<ChatResponse> doChatAsync(ChatRequest chatRequest) {
+                return java.util.concurrent.CompletableFuture.completedFuture(doChat(chatRequest));
+            }
+
+            @Override
+            public ChatResponse doChat(ChatRequest chatRequest) {
+                if (calls.getAndIncrement() == 0) {
+                    return ChatResponse.builder()
+                            .aiMessage(AiMessage.from(ToolExecutionRequest.builder()
+                                    .id("1")
+                                    .name("getWeather")
+                                    .arguments("{\"arg0\": \"Munich\"}")
+                                    .build()))
+                            .build();
+                }
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from("It is sunny"))
+                        .build();
+            }
+        };
+    }
+}

--- a/langchain4j-spring-boot-starter/src/main/java/dev/langchain4j/service/spring/ExecutorProviderAutoConfig.java
+++ b/langchain4j-spring-boot-starter/src/main/java/dev/langchain4j/service/spring/ExecutorProviderAutoConfig.java
@@ -1,0 +1,67 @@
+package dev.langchain4j.service.spring;
+
+import dev.langchain4j.spi.ExecutorProvider;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.util.concurrent.Executor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.AsyncTaskExecutor;
+
+/**
+ * Routes the work LangChain4j runs off the caller thread - blocking tools, offloaded retrieval, retry backoff -
+ * through Spring's application {@link AsyncTaskExecutor} instead of LangChain4j's own default executor.
+ * <p>
+ * This is what makes ambient context follow an asynchronous or reactive AI Service invocation: LangChain4j does
+ * not copy {@code ThreadLocal} state across its thread hops, so tracing spans, MDC and security context survive
+ * only if the executor itself propagates them. Spring's executor does when it is configured with a
+ * {@code TaskDecorator} (Micrometer's context propagation and Spring Security both install one), and using it
+ * also means LangChain4j honours the pool sizing the application already declares under
+ * {@code spring.task.execution.*} rather than creating threads of its own.
+ * <p>
+ * Off by default, because {@link ExecutorProvider#set(ExecutorProvider)} is process-wide rather than scoped to an
+ * application context: switching it on changes the executor for every LangChain4j usage in the JVM. Enable it
+ * with:
+ *
+ * <pre>
+ * langchain4j.executor.use-spring-task-executor=true
+ * </pre>
+ *
+ * A programmatically registered provider is restored when the context shuts down, so a test that starts and stops
+ * a context does not leak its executor into the next one.
+ */
+@Configuration
+@ConditionalOnProperty(name = "langchain4j.executor.use-spring-task-executor", havingValue = "true")
+public class ExecutorProviderAutoConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(ExecutorProviderAutoConfig.class);
+
+    private final ObjectProvider<AsyncTaskExecutor> taskExecutor;
+    private ExecutorProvider previous;
+
+    public ExecutorProviderAutoConfig(ObjectProvider<AsyncTaskExecutor> taskExecutor) {
+        this.taskExecutor = taskExecutor;
+    }
+
+    @PostConstruct
+    void useSpringTaskExecutor() {
+        Executor executor = taskExecutor.getIfAvailable();
+        if (executor == null) {
+            log.warn("langchain4j.executor.use-spring-task-executor is enabled, but no AsyncTaskExecutor bean was"
+                    + " found. LangChain4j keeps using its own default executor.");
+            return;
+        }
+        previous = ExecutorProvider.get();
+        ExecutorProvider.set(() -> executor);
+        log.debug("LangChain4j will run offloaded work on the Spring task executor: {}", executor);
+    }
+
+    @PreDestroy
+    void restorePreviousProvider() {
+        ExecutorProvider.set(previous);
+    }
+}

--- a/langchain4j-spring-boot-starter/src/main/java/dev/langchain4j/spring/LangChain4jAutoConfig.java
+++ b/langchain4j-spring-boot-starter/src/main/java/dev/langchain4j/spring/LangChain4jAutoConfig.java
@@ -3,12 +3,14 @@ package dev.langchain4j.spring;
 import dev.langchain4j.rag.spring.RagAutoConfig;
 import dev.langchain4j.service.spring.AiServiceScannerProcessor;
 import dev.langchain4j.service.spring.AiServicesAutoConfig;
+import dev.langchain4j.service.spring.ExecutorProviderAutoConfig;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Import;
 
 @AutoConfiguration
 @Import({
         AiServicesAutoConfig.class,
+        ExecutorProviderAutoConfig.class,
         RagAutoConfig.class,
         AiServiceScannerProcessor.class
 })

--- a/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/ExecutorProviderAutoConfigTest.java
+++ b/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/service/spring/ExecutorProviderAutoConfigTest.java
@@ -1,0 +1,48 @@
+package dev.langchain4j.service.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.spi.ExecutorProvider;
+import java.util.concurrent.Executor;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.task.AsyncTaskExecutor;
+
+class ExecutorProviderAutoConfigTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(TaskExecutionAutoConfiguration.class))
+            .withUserConfiguration(ExecutorProviderAutoConfig.class);
+
+    @Test
+    void does_nothing_unless_the_property_is_set() {
+        ExecutorProvider before = ExecutorProvider.get();
+
+        runner.run(context -> assertThat(ExecutorProvider.get()).isSameAs(before));
+    }
+
+    @Test
+    void routes_offloaded_work_through_the_Spring_task_executor_when_enabled() {
+        runner.withPropertyValues("langchain4j.executor.use-spring-task-executor=true")
+                .run(context -> {
+                    Executor spring = context.getBean(AsyncTaskExecutor.class);
+
+                    assertThat(ExecutorProvider.get()).isNotNull();
+                    assertThat(ExecutorProvider.get().executor()).isSameAs(spring);
+                });
+    }
+
+    @Test
+    void restores_the_previous_provider_when_the_context_closes() {
+        // ExecutorProvider.set is process-wide, so a context that took it over has to give it back - otherwise the
+        // next context, or the next test, silently inherits an executor belonging to a closed application.
+        ExecutorProvider before = ExecutorProvider.get();
+
+        runner.withPropertyValues("langchain4j.executor.use-spring-task-executor=true")
+                .run(context -> assertThat(ExecutorProvider.get()).isNotNull());
+
+        assertThat(ExecutorProvider.get()).isSameAs(before);
+    }
+}


### PR DESCRIPTION
## Issue

Follow-up to [langchain4j#5527](https://github.com/langchain4j/langchain4j/pull/5527), which added non-blocking
AI Services in langchain4j 1.20.0.

## Change

An AI Service method can now return `CompletableFuture<T>` or `Flow.Publisher<...>` and run without blocking the
calling thread. This adds the Reactor bindings for that, plus the piece a Spring Boot application needs to make
its own context follow the work.

### Reactor bindings (`langchain4j-reactor`)

| Adapter | SPI | Return types |
|---|---|---|
| `MonoCompletableFutureAdapter` | `CompletableFutureAdapter` | `Mono<T>` — both directions, so a `@Tool` method may also return a `Mono` |
| `FluxPublisherAdapter` | `PublisherAdapter` | `Flux<AiServiceStreamingEvent>` |

```java
interface Assistant {
    Mono<String> answer(String userMessage);
    Flux<AiServiceStreamingEvent> events(String userMessage);
}
```

**`Flux<String>` is deliberately left alone**, and still goes through `TokenStreamToFluxAdapter`. `AiServices`
consults a `PublisherAdapter` before a `TokenStreamAdapter`, so claiming `Flux<String>` here would move every
existing `Flux<String>` method onto the non-blocking path. That path only works with providers implementing the
reactive chat SPI, and it also changes tool semantics (tools run concurrently; tool execution and argument errors
swap which one fails the invocation). Neither should happen silently to code that already works, so a test pins
that `canAdapt(Flux<String>)` stays `false`.

### Spring's executor for offloaded work (`langchain4j-spring-boot-starter`)

Nothing wired `ExecutorProvider`, so the work LangChain4j runs off the caller thread — blocking tools, offloaded
retrieval, retry backoff — used its own default executor and ignored the application's.

```properties
langchain4j.executor.use-spring-task-executor=true
```

With this, offloads go through Spring's `AsyncTaskExecutor`. That matters because LangChain4j does not copy
`ThreadLocal` state across its thread hops, so tracing spans, MDC and security context survive only if the
executor propagates them — which Spring's does once a `TaskDecorator` is installed (Micrometer context
propagation and Spring Security both install one). The pool then also follows `spring.task.execution.*` instead
of LangChain4j creating threads of its own.

Off by default on purpose: `ExecutorProvider.set(...)` is process-wide rather than scoped to an application
context, so taking it over should be a decision rather than a side effect of adding a starter. The previous
provider is restored on shutdown, so a context that starts and stops does not leak its executor into the next one.

## Provider support

⚠️ These return types only work with providers that implement the non-blocking SPI — currently OpenAI (Chat
Completions and Responses), Anthropic and Bedrock. Against any other provider they compile and then fail at
runtime with `AsyncNotSupportedException`; there is no silent fallback to a blocking call. `Flux<String>` is
unaffected and keeps working everywhere.

The same applies within a call: chat memory works out of the box (`MessageWindowChatMemory` implements the async
methods), but a guardrail must override `validateAsync` even if it does no I/O, and a blocking content retriever
needs `offloadBlocking(true)`.

## Tests

18 tests, all deterministic and offline:

- `Mono<String>` and `Flux<AiServiceStreamingEvent>` end to end
- tools: a blocking `@Tool` and a `Mono`-returning `@Tool`
- cancellation reaching the underlying future; error propagation
- chat memory accumulating across calls
- RAG with an async retriever, and with a blocking one under `offloadBlocking(true)`
- guardrails, async and blocking-only
- the executor auto-config in all three states: off by default, wired when enabled, restored on context close

The "works" cases make the blocking method throw, so they prove the async path never falls back to it; the
"refuses" cases assert the actionable message a user gets when a component has not implemented its asynchronous
counterpart.

## General checklist

- [x] There are no breaking changes
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
