### PR TITLE
Use the official OllamaContainer in the Ollama starter ITs, and assert model pulls succeed

### DIFF
--- a/langchain4j-ollama-spring-boot-starter/pom.xml
+++ b/langchain4j-ollama-spring-boot-starter/pom.xml
@@ -75,6 +75,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>ollama</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/langchain4j-ollama-spring-boot-starter/src/test/java/dev/langchain4j/ollama/spring/AutoConfigIT.java
+++ b/langchain4j-ollama-spring-boot-starter/src/test/java/dev/langchain4j/ollama/spring/AutoConfigIT.java
@@ -22,14 +22,15 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
-import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.ExecResult;
+import org.testcontainers.ollama.OllamaContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
 import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.model.chat.Capability.RESPONSE_FORMAT_JSON_SCHEMA;
-import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -43,15 +44,26 @@ class AutoConfigIT {
     private static final String EMBEDDING_MODEL_NAME = "all-minilm";
     private static final int EMBEDDING_MODEL_DIMENSION = 384;
 
-    static GenericContainer<?> ollama;
+    static OllamaContainer ollama;
 
     @BeforeAll
-    static void beforeAll() throws IOException, InterruptedException {
+    static void beforeAll() {
         if (isNullOrEmpty(OLLAMA_BASE_URL)) {
-            ollama = new GenericContainer<>(OLLAMA_IMAGE).withExposedPorts(11434);
+            ollama = new OllamaContainer(DockerImageName.parse(OLLAMA_IMAGE));
             ollama.start();
-            ollama.execInContainer("ollama", "pull", MODEL_NAME);
-            ollama.execInContainer("ollama", "pull", EMBEDDING_MODEL_NAME);
+            pullModel(ollama, MODEL_NAME);
+            pullModel(ollama, EMBEDDING_MODEL_NAME);
+        }
+    }
+
+    private static void pullModel(OllamaContainer ollama, String modelName) {
+        try {
+            ExecResult result = ollama.execInContainer("ollama", "pull", modelName);
+            assertThat(result.getExitCode())
+                    .as("ollama pull %s: %s", modelName, result.getStderr())
+                    .isZero();
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException("Error pulling model " + modelName, e);
         }
     }
 
@@ -64,7 +76,7 @@ class AutoConfigIT {
 
     private static String baseUrl() {
         if (isNullOrEmpty(OLLAMA_BASE_URL)) {
-            return format("http://%s:%s", ollama.getHost(), ollama.getFirstMappedPort());
+            return ollama.getEndpoint();
         } else {
             return OLLAMA_BASE_URL;
         }


### PR DESCRIPTION
## Issue
Closes langchain4j/langchain4j#2101

## Change

Improves `AutoConfigIT` of the Ollama Spring Boot starter, as requested in the issue:

- Replaces the manually configured `GenericContainer` with the official `org.testcontainers:ollama` module (`OllamaContainer`), which declares the Ollama port itself and provides `getEndpoint()`.
- Asserts the exit code of `ollama pull` for both models (`phi`, `all-minilm`), so a missing or renamed model now fails fast with a clear message instead of surfacing as confusing downstream test failures.
- Adds `org.testcontainers:ollama` as a test dependency (version managed by the Spring Boot BOM).
- The `OLLAMA_BASE_URL` escape hatch for pointing the ITs at an external Ollama instance is preserved.

Note: the Ollama ITs are excluded from the PR build via `-DskipOllamaITs` and run in the nightly workflow; Docker is not available in my local environment, so they were verified by compile + review and will be exercised by the nightly run.

## General checklist
- [X] There are no breaking changes
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)