### PR TITLE
Restore Spring configuration metadata on JDK 23+

### DIFF
--- a/langchain4j-open-ai-spring-boot-starter/src/test/java/dev/langchain4j/openai/spring/ConfigurationMetadataTest.java
+++ b/langchain4j-open-ai-spring-boot-starter/src/test/java/dev/langchain4j/openai/spring/ConfigurationMetadataTest.java
@@ -1,0 +1,17 @@
+package dev.langchain4j.openai.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class ConfigurationMetadataTest {
+
+    @Test
+    void shouldGenerateSpringConfigurationMetadata() throws Exception {
+        Path classesDirectory =
+                Path.of(Properties.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+
+        assertThat(classesDirectory.resolve("META-INF/spring-configuration-metadata.json")).isRegularFile();
+    }
+}

--- a/langchain4j-open-ai-spring-boot-starter/src/test/java/dev/langchain4j/openai/spring/ConfigurationMetadataTest.java
+++ b/langchain4j-open-ai-spring-boot-starter/src/test/java/dev/langchain4j/openai/spring/ConfigurationMetadataTest.java
@@ -1,7 +1,9 @@
 package dev.langchain4j.openai.spring;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 
@@ -9,9 +11,25 @@ class ConfigurationMetadataTest {
 
     @Test
     void shouldGenerateSpringConfigurationMetadata() throws Exception {
-        Path classesDirectory =
-                Path.of(Properties.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+        assertThat(classesDirectory().resolve("META-INF/spring-configuration-metadata.json"))
+                .isRegularFile()
+                .content(UTF_8)
+                .contains("\"" + Properties.PREFIX + ".chat-model.api-key\"");
+    }
 
-        assertThat(classesDirectory.resolve("META-INF/spring-configuration-metadata.json")).isRegularFile();
+    @Test
+    void shouldGenerateSpringAutoConfigureMetadata() throws Exception {
+        assertThat(classesDirectory().resolve("META-INF/spring-autoconfigure-metadata.properties"))
+                .isRegularFile()
+                .content(UTF_8)
+                .contains(AutoConfig.class.getName());
+    }
+
+    private static Path classesDirectory() throws URISyntaxException {
+        return Path.of(Properties.class
+                .getProtectionDomain()
+                .getCodeSource()
+                .getLocation()
+                .toURI());
     }
 }

--- a/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/rag/spring/ConfigurationMetadataTest.java
+++ b/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/rag/spring/ConfigurationMetadataTest.java
@@ -1,0 +1,17 @@
+package dev.langchain4j.rag.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class ConfigurationMetadataTest {
+
+    @Test
+    void shouldGenerateSpringConfigurationMetadata() throws Exception {
+        Path classesDirectory =
+                Path.of(RagProperties.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+
+        assertThat(classesDirectory.resolve("META-INF/spring-configuration-metadata.json")).isRegularFile();
+    }
+}

--- a/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/rag/spring/ConfigurationMetadataTest.java
+++ b/langchain4j-spring-boot-starter/src/test/java/dev/langchain4j/rag/spring/ConfigurationMetadataTest.java
@@ -1,7 +1,10 @@
 package dev.langchain4j.rag.spring;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.langchain4j.spring.LangChain4jAutoConfig;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 
@@ -9,9 +12,25 @@ class ConfigurationMetadataTest {
 
     @Test
     void shouldGenerateSpringConfigurationMetadata() throws Exception {
-        Path classesDirectory =
-                Path.of(RagProperties.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+        assertThat(classesDirectory().resolve("META-INF/spring-configuration-metadata.json"))
+                .isRegularFile()
+                .content(UTF_8)
+                .contains("\"" + RagProperties.PREFIX + ".retrieval.max-results\"");
+    }
 
-        assertThat(classesDirectory.resolve("META-INF/spring-configuration-metadata.json")).isRegularFile();
+    @Test
+    void shouldGenerateSpringAutoConfigureMetadata() throws Exception {
+        assertThat(classesDirectory().resolve("META-INF/spring-autoconfigure-metadata.properties"))
+                .isRegularFile()
+                .content(UTF_8)
+                .contains(LangChain4jAutoConfig.class.getName());
+    }
+
+    private static Path classesDirectory() throws URISyntaxException {
+        return Path.of(RagProperties.class
+                .getProtectionDomain()
+                .getCodeSource()
+                .getLocation()
+                .toURI());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,8 @@
         <langchain4j.beta.version>1.21.0-beta31-SNAPSHOT</langchain4j.beta.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <!-- JDK 23+ disables classpath annotation processor discovery unless explicitly enabled. -->
+        <maven.compiler.proc>full</maven.compiler.proc>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.outputTimestamp>2026-09-07T10:56:10Z</project.build.outputTimestamp>
         <spring.boot3.version>3.5.13</spring.boot3.version>


### PR DESCRIPTION

## Issue

Fixes langchain4j/langchain4j#6342

## Change

Since JDK 23, `javac` no longer discovers annotation processors on the classpath unless annotation processing is explicitly enabled. The release workflow moved from JDK 17 to JDK 25 in March 2026, so `spring-boot-configuration-processor` and `spring-boot-autoconfigure-processor` silently stopped running. Both are still declared in every starter POM; nothing was invoking them.

Published starter jars have therefore shipped without `META-INF/spring-configuration-metadata.json` and `META-INF/spring-autoconfigure-metadata.properties` since `1.13.0-beta23`. Properties still bind correctly at runtime, but IDEs cannot autocomplete, validate or document any `langchain4j.*` property.

- set `maven.compiler.proc=full` in the parent POM, restoring the pre-JDK-23 default for every module
- add metadata regression tests to the core and OpenAI starters, asserting that both metadata files are generated and that each contains the entries its processor is expected to produce

`-proc:full` exists in JDK 21 and later, and was backported to JDK 17.0.11, so it is safe for the whole 17 / 21 / 25 CI matrix.

## Verification

- `1.12.2-beta22` (built 2026-03-06) still contains both metadata files; `1.13.0-beta23` (2026-04-09) and every release since contain neither, matching the release workflow's JDK 17 to 25 bump
- the new tests fail on JDK 25 without the POM change and pass with it
- `mvn clean install` is green for all 36 reactor modules on JDK 25, and on JDK 17 for the changed modules
- all 30 reactor modules declaring `@ConfigurationProperties` now produce both metadata files; the OpenAI starter jar again carries 8 groups and 131 properties

## General checklist

- [x] There are no breaking changes
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) — not applicable, no user-facing API change
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) — not applicable
